### PR TITLE
Use default empty pool in vagrant.New() to avoid checking in State().

### DIFF
--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -482,8 +482,12 @@ func outputSensitiveConfig(testConfig TestContextType) {
 }
 
 func outputSensitiveState(testState TestState) {
-	testState.Login.Password = mask
-	testState.ServiceLogin.Password = mask
+	if testState.Login != nil {
+		testState.Login.Password = mask
+	}
+	if testState.ServiceLogin != nil {
+		testState.ServiceLogin.Password = mask
+	}
 	log.Debugf("[STATE]: %#v", testState)
 }
 

--- a/infra/vagrant/vagrant.go
+++ b/infra/vagrant/vagrant.go
@@ -30,7 +30,9 @@ func New(stateDir string, config Config) (*vagrant, error) {
 			constants.FieldCluster:     config.ClusterName,
 		}),
 		stateDir: stateDir,
-		Config:   config,
+		// will be reset in Create
+		pool:   infra.NewNodePool(nil, nil),
+		Config: config,
 	}, nil
 }
 


### PR DESCRIPTION
Check if login blocks are non-nil before outputting.