### PR TITLE
Prioritize configuration when restoring state

### DIFF
--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -441,13 +441,18 @@ func provisionerFromState(infraConfig infra.Config, testState TestState) (provis
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	numNodes := len(testState.ProvisionerState.Nodes)
+	if TestContext.Onprem.NumNodes > 0 {
+		// Always override from configuration if available
+		numNodes = TestContext.Onprem.NumNodes
+	}
 	switch testState.Provisioner {
 	case provisionerTerraform:
 		config := terraform.Config{
 			Config:       infraConfig,
 			ScriptPath:   TestContext.Onprem.ScriptPath,
 			InstallerURL: TestContext.Onprem.InstallerURL,
-			NumNodes:     len(testState.ProvisionerState.Nodes),
+			NumNodes:     numNodes,
 			AccessKey:    TestContext.AWS.AccessKey,
 			SecretKey:    TestContext.AWS.SecretKey,
 			KeyPair:      TestContext.AWS.KeyPair,
@@ -464,7 +469,7 @@ func provisionerFromState(infraConfig infra.Config, testState TestState) (provis
 			Config:       infraConfig,
 			ScriptPath:   TestContext.Onprem.ScriptPath,
 			InstallerURL: TestContext.Onprem.InstallerURL,
-			NumNodes:     len(testState.ProvisionerState.Nodes),
+			NumNodes:     numNodes,
 		}
 		err := config.Validate()
 		if err != nil {


### PR DESCRIPTION
In case the state was saved before complete initialization of infrastructure (as state is saved in batches, with the first being as soon as any state is available), the state might not reflect the actual number of nodes provisioned - always override number of nodes from configuration if available.