### PR TITLE
Collect installer/agent logs even w/o service login configured

### DIFF
--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -34,7 +34,6 @@ func ConfigureFlags() {
 	initLogger(debugFlag)
 
 	if debugFlag {
-		// TODO: make port configurable
 		debug.StartProfiling(fmt.Sprintf("localhost:%v", debugPort))
 	}
 


### PR DESCRIPTION
Failure to collecting OpsCenter logs should not prevent CoreDump from collecting install and/or agent logs.