### PR TITLE
Avoid using INSTALLER_URL as a wizard mode detector

### DIFF
--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -73,8 +73,6 @@ func ConfigureFlags() {
 
 	if mode == wizardMode || TestContext.Wizard {
 		TestContext.Wizard = true
-	} else {
-		TestContext.Onprem.InstallerURL = ""
 	}
 
 	if provisionerName != "" {

--- a/infra/infra.go
+++ b/infra/infra.go
@@ -72,7 +72,10 @@ type Infra interface {
 type Provisioner interface {
 	// Create provisions a new cluster and returns a reference
 	// to the node that can be used to run installation
-	Create() (installer Node, err error)
+	//
+	// withInstaller specifies if the provisioner should select an installer node.
+	// Installer node selection is provisioner-specific
+	Create(withInstaller bool) (installer Node, err error)
 	// Destroy the infrastructures created by Create.
 	// After the call to Destroy the provisioner is invalid and no
 	// other methods can be used

--- a/infra/terraform/terraform.go
+++ b/infra/terraform/terraform.go
@@ -57,7 +57,7 @@ func NewFromState(config Config, stateConfig infra.ProvisionerState) (*terraform
 	return t, nil
 }
 
-func (r *terraform) Create() (installer infra.Node, err error) {
+func (r *terraform) Create(withInstaller bool) (installer infra.Node, err error) {
 	err = system.CopyFile(filepath.Join(r.stateDir, "terraform.tf"), r.ScriptPath)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -68,7 +68,7 @@ func (r *terraform) Create() (installer infra.Node, err error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if r.Config.InstallerURL != "" {
+	if withInstaller {
 		// find installer public IP
 		match := reInstallerIP.FindStringSubmatch(output)
 		if len(match) != 2 {


### PR DESCRIPTION
Avoid using INSTALLER_URL as a wizard mode detector - do not remove from configuration environment, and determine if a provisioner should select an installer node only during infrastructure boostrapping.