### PR TITLE
Target "vendor" needs to be phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ $(TARGETS): clean vendor
 	cd $(SRCDIR) && \
 		go test -c -i ./$(subst robotest-,,$@) -o build/robotest-$@
 
+
+.PHONY: vendor
 vendor:
 	cd $(SRCDIR) && glide install
 


### PR DESCRIPTION
Target "vendor" needs to be phony to work - otherwise, it will use vendor directory as a source of truth and the first build will fail.