### PR TITLE
Enable eth0 in trusted zone for firewalld

### DIFF
--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -34,7 +34,8 @@ wipefs -af /dev/sdd || :
 # 
 firewall-cmd --zone=trusted --add-source=10.244.0.0/16 --permanent # pod subnet
 firewall-cmd --zone=trusted --add-source=10.100.0.0/16 --permanent # service subnet
-firewall-cmd --zone=trusted --add-masquerade --permanent # masquerading so packets can be routed back
+firewall-cmd --zone=trusted --add-interface=eth0 --permanent       # enable eth0 in trusted zone so nodes can communicate
+firewall-cmd --zone=trusted --add-masquerade --permanent           # masquerading so packets can be routed back
 firewall-cmd --reload
 systemctl restart firewalld
 

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -4,6 +4,20 @@
 #
 set -euo pipefail
 
+function devices {
+    lsblk --raw --noheadings -I 8,9,202,252,253,259 $@
+}
+
+function get_docker_device {
+    for device in $(devices --output=NAME); do
+        local partitions=$(devices --output=NAME /dev/$device | wc -l)
+        if (( $partitions==1 )) && [[ -z "$(devices --output=FSTYPE /dev/$device)" ]]; then
+            echo $device
+            exit 0
+        fi
+    done
+}
+
 touch /var/lib/bootstrap_started
 
 systemctl stop dnsmasq
@@ -25,9 +39,9 @@ mount /var/lib/gravity/planet/etcd
 chown -R 1000:1000 /var/lib/gravity /var/lib/data /var/lib/gravity/planet/etcd
 sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
-# apparently centos WAAgent on azure will auto create FS and mount all data disks, need undo that
-umount /dev/sdd1 || : 
-wipefs -af /dev/sdd || :
+docker_device=$(get_docker_device)
+[ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
+echo "/dev/$docker_device" > ~/.gravity_docker_device
 
 #
 # configure firewall rules

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -41,7 +41,7 @@ sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 docker_device=$(get_docker_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
-echo "/dev/$docker_device" > ~/.gravity_docker_device
+echo "/dev/$docker_device" > /tmp/.gravity_docker_device
 
 #
 # configure firewall rules

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -267,7 +267,7 @@ func configureVM(ctx context.Context, log logrus.FieldLogger, node infra.Node, p
 	case "azure":
 		err = bootstrapAzure(ctx, g, param)
 	default:
-		return nil, trace.Errorf("unsupported cloud provider %s", param.CloudProvider)
+		return nil, trace.BadParameter("unsupported cloud provider %s", param.CloudProvider)
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -276,7 +276,7 @@ func configureVM(ctx context.Context, log logrus.FieldLogger, node infra.Node, p
 	return g, nil
 }
 
-// waitIOStabilize is a necessary workaround for Azure VMs to wait until their disk initialization processes are complete
+// waitDisks is a necessary workaround for Azure VMs to wait until their disk initialization processes are complete
 // otherwise it'll fail telekube pre-install checks
 func waitDisks(ctx context.Context, nodes []Gravity, paths []string) error {
 	errs := make(chan error, len(nodes))


### PR DESCRIPTION
Enable eth0 in trusted zone for firewalld so multiple nodes can communicate