### PR TITLE
azure: query docker device on host for redhat/centos

### DIFF
--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -41,7 +41,7 @@ sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 docker_device=$(get_docker_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
-echo "/dev/$docker_device" > /tmp/.gravity_docker_device
+echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment
 
 #
 # configure firewall rules

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -21,4 +21,7 @@ const (
 
 	// SharedReadWriteMask is a mask for a shared file with world read/write access
 	SharedReadWriteMask = 0666
+
+	// EnvDockerDevice specifies the name of the environment variable with docker device name
+	EnvDockerDevice = "DOCKER_DEVICE"
 )


### PR DESCRIPTION
Query docker device on the host and store in gravity environment file to be able to override the installer command line. Environment: azure/redhat/centos.

TODO: I want to use a later opportunity to clean up some of this code - including moving install command into a proper text template.