### PR TITLE
Custom gravity dir support

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,7 +6,10 @@ PULL ?= --pull
 
 TERRAFORM_VERSION := 0.9.3
 CHROMEDRIVER_VERSION := 2.29
-BUILD_ARGS := --build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) --build-arg CHROMEDRIVER_VERSION=$(CHROMEDRIVER_VERSION)
+
+E2E_BUILD_ARGS := --build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
+  --build-arg CHROMEDRIVER_VERSION=$(CHROMEDRIVER_VERSION)
+SUITE_BUILD_ARGS := --build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION)
 
 .PHONY: containers
 containers: $(TARGETS)
@@ -27,12 +30,16 @@ $(TARGETS): $(BINARIES)
 	cp -r ../assets/terraform $(TEMPDIR)
 	cp -a ../build/robotest-$@ $(TEMPDIR)/build/
 	cp -r $@/* $(TEMPDIR)/
-	cd $(TEMPDIR) && docker build $(BUILD_ARGS) --rm=true $(PULL) -t $(IMAGE) .
+	if [ "$@" = "e2e" ]; then \
+	  cd $(TEMPDIR) && docker build $(E2E_BUILD_ARGS) --rm=true $(PULL) -t $(IMAGE) . ; \
+	else \
+	  cd $(TEMPDIR) && docker build $(SUITE_BUILD_ARGS) --rm=true $(PULL) -t $(IMAGE) . ; \
+	fi
 	rm -rf $(TEMPDIR)
 	@echo Built $(IMAGE)
 
-# Publish 
- 
+# Publish
+
 DOCKER_IMG = $(addprefix $(DOCKER_REPO)/robotest-,$(TARGETS))
 
 .PHONY: publish

--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -10,8 +10,8 @@ if [ -f $INSTALLER_URL ] ; then
 	INSTALLER_FILE='/robotest/installer.tar'
 fi
 
-# OS could be ubuntu,centos,redhat 
-# storage driver: could be devicemapper,loopback,overlay,overlay2 
+# OS could be ubuntu,centos,redhat
+# storage driver: could be devicemapper,loopback,overlay,overlay2
 #  separate multiple values by comma for OS and storage driver
 TEST_OS=${TEST_OS:-ubuntu}
 STORAGE_DRIVER=${STORAGE_DRIVER:-devicemapper}
@@ -35,13 +35,13 @@ ROBOTEST_VERSION=${ROBOTEST_VERSION:-stable}
 check_files () {
 	ABORT=
 	for v in $@ ; do
-		if [ ! -f "${v}" ] ; then 
+		if [ ! -f "${v}" ] ; then
 			echo "${v} does not exist"
 			ABORT=true
 		fi
 	done
 
-	if [ ! -z $ABORT ] ; then 
+	if [ ! -z $ABORT ] ; then
 		exit 1 ;
 	fi
 }
@@ -52,7 +52,7 @@ if [ $DEPLOY_TO != "azure" ] && [ $DEPLOY_TO != "aws" ] ; then
 fi
 
 if [ $DEPLOY_TO == "aws" ] || [[ $INSTALLER_URL = 's3://'* ]] || [[ ${UPGRADE_FROM:-} = 's3://'* ]]; then
-check_files ${SSH_KEY} 
+check_files ${SSH_KEY}
 AWS_CONFIG="aws:
   access_key: ${AWS_ACCESS_KEY}
   secret_key: ${AWS_SECRET_KEY}
@@ -64,9 +64,9 @@ AWS_CONFIG="aws:
   docker_device: /dev/xvdb"
 fi
 
-if [ $DEPLOY_TO == "azure" ] ; then 
+if [ $DEPLOY_TO == "azure" ] ; then
 check_files ${SSH_KEY} ${SSH_PUB}
-AZURE_CONFIG="azure: 
+AZURE_CONFIG="azure:
   subscription_id: ${AZURE_SUBSCRIPTION_ID}
   client_id: ${AZURE_CLIENT_ID}
   client_secret: ${AZURE_CLIENT_SECRET}

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -76,7 +76,9 @@ func (c *TestContext) OfflineInstall(nodes []Gravity, param InstallParam) error 
 			err := n.Join(ctx, JoinCmd{
 				PeerAddr: master.Node().PrivateAddr(),
 				Token:    param.Token,
-				Role:     param.Role})
+				Role:     param.Role,
+				StateDir: param.StateDir,
+			})
 			if err != nil {
 				n.Logger().WithError(err).Error("join failed")
 			}

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -78,7 +78,7 @@ func (c *TestContext) OfflineInstall(nodes []Gravity, param InstallParam) error 
 				Token:    param.Token,
 				Role:     param.Role})
 			if err != nil {
-				n.Logger().WithError(err).Error("Join failed")
+				n.Logger().WithError(err).Error("join failed")
 			}
 			errs <- err
 		}(node)

--- a/infra/gravity/cluster_resize.go
+++ b/infra/gravity/cluster_resize.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-func (c *TestContext) Expand(current, extra []Gravity, role string) error {
+func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
 	if len(current) == 0 || len(extra) == 0 {
 		return trace.Errorf("empty node list")
 	}
@@ -32,7 +32,9 @@ func (c *TestContext) Expand(current, extra []Gravity, role string) error {
 		err = node.Join(ctx, JoinCmd{
 			PeerAddr: joinAddr,
 			Token:    status.Token,
-			Role:     role})
+			Role:     p.Role,
+			StateDir: p.StateDir,
+		})
 		if err != nil {
 			return trace.Wrap(err, "error joining cluster on node %s: %v", node.String(), err)
 		}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -23,4 +23,10 @@ const (
 
 	// MinDiskSpeed is minimum write performance
 	MinDiskSpeed = uint64(1e7)
+
+	// NodeRole is the default role when installing/joining a node
+	NodeRole = "node"
+
+	// GravityDir is the default location of all gravity data on a node
+	GravityDir = "/var/lib/gravity"
 )

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -94,7 +94,7 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 
 		if param.ExpandBeforeShrink {
 			g.OK("expand before shrinking",
-				g.Expand(nodes, allNodes[param.NodeCount:param.NodeCount+1], param.Role))
+				g.Expand(nodes, allNodes[param.NodeCount:param.NodeCount+1], param.InstallParam))
 			nodes = append(nodes, allNodes[param.NodeCount])
 
 			roles, err := g.NodesByRole(nodes)
@@ -112,7 +112,7 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 				Info("Roles after remove")
 
 			g.OK("replace node",
-				g.Expand(nodes, allNodes[param.NodeCount:param.NodeCount+1], param.Role))
+				g.Expand(nodes, allNodes[param.NodeCount:param.NodeCount+1], param.InstallParam))
 			nodes = append(nodes, allNodes[param.NodeCount])
 		}
 

--- a/suite/sanity/resize.go
+++ b/suite/sanity/resize.go
@@ -30,7 +30,8 @@ func resize(p interface{}) (gravity.TestFunc, error) {
 		g.OK("time sync", g.CheckTimeSync(nodes))
 
 		g.OK(fmt.Sprintf("expand to %d nodes", param.ToNodes),
-			g.Expand(nodes[0:param.NodeCount], nodes[param.NodeCount:param.ToNodes], param.Role))
+			g.Expand(nodes[0:param.NodeCount], nodes[param.NodeCount:param.ToNodes],
+				param.InstallParam))
 		g.OK("status", g.Status(nodes[0:param.ToNodes]))
 	}, nil
 }

--- a/suite/sanity/sanity.go
+++ b/suite/sanity/sanity.go
@@ -1,15 +1,19 @@
 package sanity
 
 import (
-	"github.com/gravitational/robotest/lib/config"
-
 	"github.com/gravitational/robotest/infra/gravity"
+	"github.com/gravitational/robotest/lib/config"
+	"github.com/gravitational/robotest/lib/defaults"
 )
 
-var defaultInstallParam = installParam{InstallParam: gravity.InstallParam{Role: "node"}}
+var defaultInstallParam = installParam{
+	InstallParam: gravity.InstallParam{
+		Role:     defaults.NodeRole,
+		StateDir: defaults.GravityDir,
+	},
+}
 
 // Suite returns base configuration for a suite which may be further customized
-
 func Suite() *config.Config {
 	cfg := config.New()
 

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -99,7 +99,7 @@ func TestMain(t *testing.T) {
 
 	suiteCfg, there := suites[*testSuite]
 	if !there {
-		t.Fatalf("No such test suite \"%s\"", *testSuite)
+		t.Fatalf("no such test suite %q", *testSuite)
 	}
 
 	testSet, err := suiteCfg.Parse(flag.Args())


### PR DESCRIPTION
It can be provided in test json configuration dictionary, e.g.:

```
resize={"nodes":2,"to":3,"flavor":"two","state_dir":"/var/lib/gravity3"}
```

I'm planning to change one of existing gravity tests to use custom state dir so we don't have a separate test case just for this.

Also, fix robotest build - it was broken on my machine b/c docker was complaining that one of build args was unused.