### PR TITLE
Dmitri/firewalld centos

### DIFF
--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -43,6 +43,8 @@ docker_device=$(get_docker_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
 echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment
 
+systemctl enable firewalld || true
+systemctl start firewalld || true
 #
 # configure firewall rules
 # 

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -20,6 +20,9 @@ function get_empty_device {
 
 touch /var/lib/bootstrap_started
 
+# disable Hyper-V host time sync 
+echo vmbus_12 > /sys/bus/vmbus/drivers/hv_util/unbind
+
 systemctl stop dnsmasq
 systemctl disable dnsmasq
 

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -30,6 +30,8 @@ curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
 ./awscli-bundle/install -i /usr/local/aws -b /usr/bin/aws
 
+# dump devices
+lsblk -I 8,9,202,252,253,259 --output-all -P
 etcd_device=$(get_empty_device)
 [ ! -z "$etcd_device" ] || (>&2 echo no suitable device for etcd; exit 1)
 
@@ -43,6 +45,8 @@ chown -R 1000:1000 /var/lib/gravity /var/lib/data /var/lib/gravity/planet/etcd
 sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 sync
+# dump devices
+lsblk -I 8,9,202,252,253,259 --output-all -P
 docker_device=$(get_empty_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
 echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -44,8 +44,8 @@ docker_device=$(get_docker_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
 echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment
 
-systemctl enable firewalld || true
-systemctl start firewalld || true
+systemctl enable firewalld
+systemctl start firewalld
 #
 # configure firewall rules
 # 

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -10,8 +10,8 @@ function devices {
 
 function get_empty_device {
     for device in $(devices --output=NAME); do
-        local partitions=$(devices --output=NAME /dev/$device | wc -l)
-        if (( $partitions==1 )) && [[ -z "$(devices --output=FSTYPE /dev/$device)" ]]; then
+        local type=$(devices --output=TYPE /dev/$device)
+        if [ "$type" != "part" ] && [[ -z "$(devices --output=FSTYPE /dev/$device)" ]]; then
             echo $device
             exit 0
         fi
@@ -30,8 +30,6 @@ curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
 ./awscli-bundle/install -i /usr/local/aws -b /usr/bin/aws
 
-# dump devices
-lsblk -I 8,9,202,252,253,259 --output-all -P
 etcd_device=$(get_empty_device)
 [ ! -z "$etcd_device" ] || (>&2 echo no suitable device for etcd; exit 1)
 
@@ -45,8 +43,6 @@ chown -R 1000:1000 /var/lib/gravity /var/lib/data /var/lib/gravity/planet/etcd
 sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
 sync
-# dump devices
-lsblk -I 8,9,202,252,253,259 --output-all -P
 docker_device=$(get_empty_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
 echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -39,6 +39,7 @@ mount /var/lib/gravity/planet/etcd
 chown -R 1000:1000 /var/lib/gravity /var/lib/data /var/lib/gravity/planet/etcd
 sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 
+sync
 docker_device=$(get_docker_device)
 [ ! -z "$docker_device" ] || (>&2 echo no suitable device for docker; exit 1)
 echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gravitational/robotest/infra"
 	"github.com/gravitational/robotest/lib/constants"
+	"github.com/gravitational/robotest/lib/defaults"
 	sshutils "github.com/gravitational/robotest/lib/ssh"
 	"github.com/gravitational/robotest/lib/wait"
 	"github.com/gravitational/trace"
@@ -380,7 +381,8 @@ func (g *gravity) Upload(ctx context.Context) error {
 
 // Upgrade takes current installer and tries to perform upgrade
 func (g *gravity) Upgrade(ctx context.Context) error {
-	return trace.Wrap(g.runOp(ctx, `upgrade $(./gravity app-package --state-dir=.)`))
+	return trace.Wrap(g.runOp(ctx,
+		fmt.Sprintf("upgrade $(./gravity app-package --state-dir=.) --etcd-retry-timeout=%v", defaults.EtcdRetryTimeout)))
 }
 
 // for cases when gravity doesn't return just opcode but an extended message

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -181,12 +181,8 @@ func (g *gravity) Install(ctx context.Context, param InstallParam) error {
 	type cmd struct {
 		InstallDir      string
 		PrivateAddr     string
-		Token           string
-		Flavor          string
 		EnvDockerDevice string
 		StorageDriver   string
-		CloudProvider   string
-		Cluster         string
 		InstallParam
 	}
 
@@ -196,10 +192,6 @@ func (g *gravity) Install(ctx context.Context, param InstallParam) error {
 		PrivateAddr:     g.Node().PrivateAddr(),
 		EnvDockerDevice: constants.EnvDockerDevice,
 		StorageDriver:   g.param.storageDriver,
-		CloudProvider:   param.CloudProvider,
-		Token:           param.Token,
-		Flavor:          param.Flavor,
-		Cluster:         param.Cluster,
 		InstallParam:    param,
 	})
 	if err != nil {
@@ -246,7 +238,7 @@ func (g *gravity) OfflineUpdate(ctx context.Context, installerUrl string) error 
 }
 
 func (g *gravity) Join(ctx context.Context, param JoinCmd) error {
-	// cmd specify additional configuration for the install command
+	// cmd specify additional configuration for the join command
 	// collected from defaults and/or computed values
 	type cmd struct {
 		InstallDir, PrivateAddr, EnvDockerDevice string

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -29,4 +29,8 @@ const (
 
 	// GravityDir is the default location of all gravity data on a node
 	GravityDir = "/var/lib/gravity"
+
+	// EtcdRetryTimeout specifies the total timeout for retrying etcd commands
+	// in case of transient errors
+	EtcdRetryTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
  - Enable `firewalld` (the case for centos where it is not running by default) to make firewall handling ubiquitous between redhat/centos.
  - Force file buffer flush with `sync`
  - Disable timesync on redhat/centos to avoid time out of sync between the nodes