### PR TITLE
redhat / bootstrap fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ wd
 wd_suite
 run.sh
 *.sublime-workspace
+tf/

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -92,7 +92,7 @@ echo "DOCKER_DEVICE=/dev/$docker_device" > /tmp/gravity_environment
 
 systemctl disable firewalld || true
 systemctl stop firewalld || true
-iptables --flush
+iptables --flush --wait
 iptables --delete-chain
 iptables --table nat --flush
 iptables --table filter --flush

--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -103,5 +103,14 @@ modprobe br_netfilter || true
 modprobe overlay || true
 sysctl -w net.bridge.bridge-nf-call-iptables=1
 
+# make the changes permanent
+cat > /usr/lib/sysctl.d/50-telekube.conf <<EOF
+net.bridge.bridge-nf-call-iptables=1
+EOF
+cat > /etc/modules-load.d/telekube.conf <<EOF
+br_netfilter
+overlay
+EOF
+
 # robotest might SSH before bootstrap script is complete (and will fail)
 touch /var/lib/bootstrap_complete

--- a/assets/terraform/azure/node.tf
+++ b/assets/terraform/azure/node.tf
@@ -21,7 +21,8 @@ resource "azurerm_network_interface" "node" {
   ip_configuration {
     name                          = "ipconfig-${count.index}"
     subnet_id                     = "${azurerm_subnet.robotest_a.id}"
-    private_ip_address_allocation = "dynamic"
+    private_ip_address            = "10.40.2.${count.index+4}"
+    private_ip_address_allocation = "static"
     public_ip_address_id          = "${azurerm_public_ip.node.*.id[count.index]}"
   }
 }

--- a/assets/terraform/azure/os.tf
+++ b/assets/terraform/azure/os.tf
@@ -50,7 +50,7 @@ variable "os_version" {
         "ubuntu:latest"     = "16.04.201708151"
         "redhat:7.3" = "latest"
         "redhat:7.2" = "latest"
-        "redhat:7.4" = "latest"
+        "redhat:7.4" = "7.4.2017080923"
         "centos"     = "latest"
         "centos:7.4" = "7.4.20170919"
         "centos:7.3" = "7.3.20170925"


### PR DESCRIPTION
workaround some occasionally happening issues:
- pin redhat 7.4 (version `7.4.2017111521` has some `iptables` issues due to default configs)
- static IP address allocation for nodes and essential config persistence to survive reboot
