### PR TITLE
Execute post installer script

### DIFF
--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -258,6 +258,10 @@ type OnpremConfig struct {
 	// ScriptPath defines the path to the provisioner script.
 	// TODO: if unspecified, scripts in assets/<provisioner> are used
 	ScriptPath string `json:"script_path" yaml:"script_path"`
+	// PostInstallerScript defines the path on remote node
+	// to the script which should be called on installer node
+	// after downloading of the installer
+	PostInstallerScript string `json:"post_installer_script" yaml:"post_installer_script"`
 	// ExpandProfile specifies an optional name of the server profile for On-Premise expand operation.
 	// If the profile is unspecified, the test will use the first available.
 	ExpandProfile string `json:"expand_profile" yaml:"expand_profile"`
@@ -416,15 +420,16 @@ func makeTerraformConfig(infraConfig infra.Config) (config *terraform.Config, er
 	}
 
 	config = &terraform.Config{
-		Config:        infraConfig,
-		ScriptPath:    TestContext.Onprem.ScriptPath,
-		InstallerURL:  TestContext.Onprem.InstallerURL,
-		NumNodes:      TestContext.Onprem.NumNodes,
-		OS:            TestContext.Onprem.OS,
-		CloudProvider: TestContext.CloudProvider,
-		AWS:           TestContext.AWS,
-		Azure:         TestContext.Azure,
-		DockerDevice:  TestContext.Onprem.DockerDevice,
+		Config:              infraConfig,
+		ScriptPath:          TestContext.Onprem.ScriptPath,
+		InstallerURL:        TestContext.Onprem.InstallerURL,
+		NumNodes:            TestContext.Onprem.NumNodes,
+		OS:                  TestContext.Onprem.OS,
+		CloudProvider:       TestContext.CloudProvider,
+		AWS:                 TestContext.AWS,
+		Azure:               TestContext.Azure,
+		DockerDevice:        TestContext.Onprem.DockerDevice,
+		PostInstallerScript: TestContext.Onprem.PostInstallerScript,
 	}
 
 	err = config.Validate()

--- a/e2e/framework/test_context.go
+++ b/e2e/framework/test_context.go
@@ -258,9 +258,8 @@ type OnpremConfig struct {
 	// ScriptPath defines the path to the provisioner script.
 	// TODO: if unspecified, scripts in assets/<provisioner> are used
 	ScriptPath string `json:"script_path" yaml:"script_path"`
-	// PostInstallerScript defines the path on remote node
-	// to the script which should be called on installer node
-	// after downloading of the installer
+	// PostInstallerScript defines a path to the script on a remote node
+	// that is executed after the installer has been downloaded
 	PostInstallerScript string `json:"post_installer_script" yaml:"post_installer_script"`
 	// ExpandProfile specifies an optional name of the server profile for On-Premise expand operation.
 	// If the profile is unspecified, the test will use the first available.

--- a/infra/terraform/config.go
+++ b/infra/terraform/config.go
@@ -61,4 +61,8 @@ type Config struct {
 	InstallerURL string `json:"installer_url" validate:"required,url"`
 	// DockerDevice block device for docker data - set to /dev/xvdb
 	DockerDevice string `json:"docker_device" yaml:"docker_device" validate:"required"`
+	// PostInstallerScript defines the path on remote node
+	// to the script which should be called on installer node
+	// after downloading of the installer
+	PostInstallerScript string `json:"post_installer_script" yaml:"post_installer_script"`
 }

--- a/infra/terraform/config.go
+++ b/infra/terraform/config.go
@@ -61,8 +61,7 @@ type Config struct {
 	InstallerURL string `json:"installer_url" validate:"required,url"`
 	// DockerDevice block device for docker data - set to /dev/xvdb
 	DockerDevice string `json:"docker_device" yaml:"docker_device" validate:"required"`
-	// PostInstallerScript defines the path on remote node
-	// to the script which should be called on installer node
-	// after downloading of the installer
+	// PostInstallerScript defines a path to the script on a remote node
+	// that is executed after the installer has been downloaded
 	PostInstallerScript string `json:"post_installer_script" yaml:"post_installer_script"`
 }

--- a/infra/terraform/file_transfer.go
+++ b/infra/terraform/file_transfer.go
@@ -60,8 +60,10 @@ func (t *terraform) makeRemoteCommand(fileUrl, command string) (string, error) {
 		echo Downloading installer %[5]s to %[3]s ... && %[2]s && \
 		echo Creating installer dir && mkdir -p %[1]s/installer && \
 		echo Unpacking installer && tar -xvf %[3]s -C %[1]s/installer && \
+		echo Checking existence of post-downloading installer script and executing it && \
+		if [[ -f %[6]s ]]; then sudo bash -x %[6]s; fi && \
 		echo Launching command %[4]s && cd %[1]s/installer && %[4]s`,
-		homeDir, fetchCmd, outFile, command, fileUrl)
+		homeDir, fetchCmd, outFile, command, fileUrl, t.Config.PostInstallerScript)
 
 	return cmd, nil
 }

--- a/infra/terraform/file_transfer.go
+++ b/infra/terraform/file_transfer.go
@@ -1,9 +1,11 @@
 package terraform
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
 	"strings"
+	"text/template"
 
 	"github.com/gravitational/trace"
 )
@@ -50,20 +52,43 @@ func (t *terraform) makeRemoteCommand(fileUrl, command string) (string, error) {
 		return "", fmt.Errorf("unsupported URL schema %s", fileUrl)
 	}
 
-	// FIXME: migrate to ssh sequential command execution interface
-	cmd := fmt.Sprintf(`echo Testing if bootstrap completed && \
-		for i in {1..100} ; \
+	var buf bytes.Buffer
+	err = remoteCommandTemplate.Execute(&buf, remoteCmd{
+		HomeDir:             homeDir,
+		FetchCommand:        fetchCmd,
+		OutputFile:          outFile,
+		Command:             command,
+		FileURL:             fileUrl,
+		PostInstallerScript: t.Config.PostInstallerScript,
+	})
+
+	if err != nil {
+		return "", trace.Wrap(err, buf.String())
+	}
+	return buf.String(), nil
+}
+
+var remoteCommandTemplate = template.Must(
+	template.New("remote_command").Parse(`echo Testing if bootstrap completed && \
+		for i in {{"{"}}1..100{{"}"}} ; \
 			do test -f /var/lib/bootstrap_complete && break || \
 			echo Waiting for bootstrap to complete && sleep 15 ; \
 		done &&  \
-		echo Cleaning up && rm -rf %[1]s/installer/* && \
-		echo Downloading installer %[5]s to %[3]s ... && %[2]s && \
-		echo Creating installer dir && mkdir -p %[1]s/installer && \
-		echo Unpacking installer && tar -xvf %[3]s -C %[1]s/installer && \
+		echo Cleaning up && rm -rf {{.HomeDir}}/installer/* && \
+		echo Downloading installer {{.FileURL}} to {{.OutputFile}} ... && {{.FetchCommand}} && \
+		echo Creating installer dir && mkdir -p {{.HomeDir}}/installer && \
+		echo Unpacking installer && tar -xvf {{.OutputFile}} -C {{.HomeDir}}/installer && \
 		echo Checking existence of post-downloading installer script and executing it && \
-		if [[ -f %[6]s ]]; then sudo bash -x %[6]s; fi && \
-		echo Launching command %[4]s && cd %[1]s/installer && %[4]s`,
-		homeDir, fetchCmd, outFile, command, fileUrl, t.Config.PostInstallerScript)
+		if [[ -f {{.PostInstallerScript}} ]]; then sudo bash -x {{.PostInstallerScript}}; fi && \
+		echo Launching command {{.Command}} && cd {{.HomeDir}}/installer && {{.Command}}`))
 
-	return cmd, nil
+// remoteCmd specifies configuration for the command that is executed
+// on the installer node
+type remoteCmd struct {
+	HomeDir             string
+	FetchCommand        string
+	OutputFile          string
+	Command             string
+	FileURL             string
+	PostInstallerScript string
 }


### PR DESCRIPTION
Because for air-gapped applications we should configure Iptables to drop all output traffic. It is impossible to do before downloading the installer, because download procedure will fail.