### PR TITLE
Use gravity from PATH when checking status

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -225,7 +225,7 @@ var installCmdTemplate = template.Must(
 
 // Status queries cluster status
 func (g *gravity) Status(ctx context.Context) (*GravityStatus, error) {
-	cmd := fmt.Sprintf("cd %s && sudo ./gravity status --system-log-file=./telekube-system.log", g.installDir)
+	cmd := "sudo gravity status --system-log-file=./telekube-system.log"
 	status := GravityStatus{}
 	exit, err := sshutils.RunAndParse(ctx, g.Client(), g.Logger(), cmd, nil, parseStatus(&status))
 


### PR DESCRIPTION
This change makes sure that the gravity binary from PATH is used to check gravity status. Before that some of the nodes were still using the old binary (from the installer package) to check for status.

This is needed for cases when after upgrade procedure the older gravity binary can no longer query the status from the new gravity-site due to some incompatibility. For example, it happened on my Trusted Clusters PR - GetOpsCenterLinks handler was removed and thus status was always failing on nodes that used the old binary.

With this change robotest passed on my PR:

```
[robotest] ******** TEST SUITE COMPLETED **********
[robotest] FAILED d1f1d4c-upgrade3lts4-1 {"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/etPA3t
[robotest] PASSED d1f1d4c-install2-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":6,"script":null} https://goo.gl/fksMx1
[robotest] PASSED d1f1d4c-resize-1 {"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/telekube","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"devicemapper","nodes":1,"script":null,"to":3} https://goo.gl/ovei41
[robotest] FAILED d1f1d4c-upgrade3lts2-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":6,"script":null,"from":"/telekube_3.62.0.tar"} https://goo.gl/Ai5Dyr
[robotest] PASSED d1f1d4c-install3-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"devicemapper","nodes":3,"script":null} https://goo.gl/pRwMJb
[robotest] PASSED d1f1d4c-install8-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"centos","Version":"7.3"},"storage_driver":"devicemapper","nodes":6,"script":null} https://goo.gl/zrEcux
[robotest] PASSED d1f1d4c-upgrade3lts7-1 {"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/7M2Nmm
[robotest] PASSED d1f1d4c-upgrade3lts5-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":6,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/fYe2HW
[robotest] PASSED d1f1d4c-upgrade3lts3-1 {"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":1,"script":null,"from":"/telekube_3.62.0.tar"} https://goo.gl/tsZuWk
[robotest] PASSED d1f1d4c-install5-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"centos","Version":"7.3"},"storage_driver":"overlay2","nodes":3,"script":null} https://goo.gl/3pp6LS
[robotest] PASSED d1f1d4c-upgrade3lts9-1 {"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":1,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/k2Ug9f
[robotest] PASSED d1f1d4c-install4-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"devicemapper","nodes":6,"script":null} https://goo.gl/aSq8Jt
[robotest] PASSED d1f1d4c-install10-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":6,"script":null} https://goo.gl/sBStHu
[robotest] PASSED d1f1d4c-install11-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"devicemapper","nodes":3,"script":null} https://goo.gl/AzBKYk
[robotest] FAILED d1f1d4c-upgrade3lts8-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":6,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/3FLwxE
[robotest] PASSED d1f1d4c-install9-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":3,"script":null} https://goo.gl/DTw2oY
[robotest] PASSED d1f1d4c-install12-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"devicemapper","nodes":6,"script":null} https://goo.gl/4ZqT4G
[robotest] PASSED d1f1d4c-install7-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"centos","Version":"7.3"},"storage_driver":"devicemapper","nodes":3,"script":null} https://goo.gl/uAov43
[robotest] PASSED d1f1d4c-install-1 {"role":"master","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":3,"script":null} https://goo.gl/tgRUcu
[robotest] PASSED d1f1d4c-install6-1 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"centos","Version":"7.3"},"storage_driver":"overlay2","nodes":6,"script":null} https://goo.gl/Qvo2WT
[robotest] PASSED d1f1d4c-upgrade3lts-1 {"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/telekube_3.62.0.tar"} https://goo.gl/pCiHx2
[robotest] PASSED d1f1d4c-upgrade3lts6-1 {"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":1,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/2hEiEr
[robotest] PASSED d1f1d4c-upgrade3lts2-1-T2 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":6,"script":null,"from":"/telekube_3.62.0.tar"} https://goo.gl/Cegv75
[robotest] PASSED d1f1d4c-upgrade3lts4-1-T2 {"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7.4"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/jLZCAE
[robotest] PASSED d1f1d4c-upgrade3lts8-1-T2 {"role":"node","cluster":"","flavor":"six","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"latest"},"storage_driver":"overlay2","nodes":6,"script":null,"from":"/telekube_4.44.0.tar"} https://goo.gl/MP5nZi
[robotest] PASS
```