### PR TITLE
Destroy resources using a fresh context.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ $(TARGETS): vendor
 		go test -c -i ./$(subst robotest-,,$@) -o build/robotest-$@
 
 vendor: glide.yaml
-	rm -rf ./.glide ./vendor
 	cd $(SRCDIR) && glide install
 
 .PHONY: clean

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -236,7 +236,7 @@ func (c *TestContext) provisionCloud(cfg ProvisionerConfig) ([]Gravity, DestroyF
 	gravityNodes, err := configureVMs(ctx, c.Logger(), *params, nodes)
 	if err != nil {
 		c.Logger().WithError(err).Error("some nodes initialization failed, teardown this setup as non-usable")
-		return nil, nil, trace.NewAggregate(err, destroyFn(ctx))
+		return nil, nil, trace.NewAggregate(err, destroyResource(destroyFn))
 	}
 
 	err = c.postProvision(cfg, gravityNodes)
@@ -427,4 +427,12 @@ func waitDisk(ctx context.Context, node Gravity, paths []string, minSpeed uint64
 		return nil
 	})
 	return trace.Wrap(err)
+}
+
+// destroyResource executes the specified destroy handler using
+// default context
+func destroyResource(handler func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), finalTeardownTimeout)
+	defer cancel()
+	return trace.Wrap(handler(ctx))
 }


### PR DESCRIPTION
I've been seeing a lot of resources left behind after multiple robotest runs. I think this happens when the initial bootstrapping fails for some reason and then the already expired provisioning context is used in a delete operation:
```
12:05:45 [robotest] time="2018-03-01T12:05:36Z" level=error msg="context timed out" 
12:05:45 [robotest] time="2018-03-01T12:05:36Z" level=error msg="context timed out" 
12:05:45 [robotest] time="2018-03-01T12:05:36Z" level=error msg="context timed out" 
12:05:45 [robotest] level=error msg="some nodes initialization failed, teardown this setup as non-usable" error="timed out" logs="https://goo.gl/GYyqsY" where=[/infra/gravity/provision.go:238] 
12:05:45 [robotest] level=error msg="VMs ready" elapsed=32m30.210463291s error="timed out, azureDestroy Delete https://management.azure.com/subscriptions/****/resourcegroups/3898490-install3-1-redhat7.4-devicemapper-3n?api-version=2016-09-01: context deadline exceeded" logs="https://goo.gl/GYyqsY" name=3898490-install3-1 where=[/suite/sanity/install.go:43] 
```

I also removed the explicit refetching of the whole vendor tree on branch switch which takes up to 5min on my system. Instead, the `robotest-publish` has been updated to do `make clean build` which would account for any changes during a publish step.
It might break development build but I think it's better to be explicit about cleaning up the vendor directory anyways.