### PR TITLE
Pin the redhat/centos 7.4 versions instead of using latest 

### DIFF
--- a/assets/terraform/azure/os.tf
+++ b/assets/terraform/azure/os.tf
@@ -49,12 +49,12 @@ variable "os_version" {
 
     default = {
         "ubuntu:latest"     = "16.04.201708151"
-        "redhat:7.3" = "latest"
         "redhat:7.2" = "latest"
-        "redhat:7.4" = "latest"
-        "centos:7.4" = "latest"
-        "centos:7.3" = "7.3.20170925"
+        "redhat:7.3" = "latest"
+        "redhat:7.4" = "7.4.2017112900"
         "centos:7.2" = "7.2.20170517"
+        "centos:7.3" = "7.3.20170925"
+        "centos:7.4" = "7.4.20171212"
         "debian"     = "latest"
         "suse"       = "2017.09.07"
     }


### PR DESCRIPTION
Currently, `7.4` version of Redhat/CentOS use `CI` variants of the VM images as supporting cloud-init. Although `cloud-init` is not used, they fix an issue with bootstrapping.
Pin the VM image versions instead of using `latest` to avoid unexpected updates.