### PR TITLE
Relax "ParseDDOutput" to allow lose output

### DIFF
--- a/assets/terraform/azure/bootstrap/centos.sh
+++ b/assets/terraform/azure/bootstrap/centos.sh
@@ -38,6 +38,13 @@ function get_timesync_bus_name {
   done
 }
 
+function add_host {
+  local hostname=$(hostname)
+  if ! grep -q "$hostname" /etc/hosts; then
+    echo -e "127.0.0.1\t$hostname" >> /etc/hosts
+  fi
+}
+
 touch /var/lib/bootstrap_started
 
 timesync_bus_name=$(get_timesync_bus_name)
@@ -121,6 +128,8 @@ ip_tables
 iptable_filter
 iptable_nat
 EOF
+
+add_host
 
 # robotest might SSH before bootstrap script is complete (and will fail)
 touch /var/lib/bootstrap_complete

--- a/assets/terraform/azure/bootstrap/ubuntu.sh
+++ b/assets/terraform/azure/bootstrap/ubuntu.sh
@@ -4,6 +4,13 @@
 #
 set -euo pipefail
 
+function add_host {
+  local hostname=$(hostname)
+  if ! grep -q "$hostname" /etc/hosts; then
+    echo -e "127.0.0.1\t$hostname" >> /etc/hosts
+  fi
+}
+
 touch /var/lib/bootstrap_started
 
 # disable Hyper-V time sync
@@ -46,6 +53,8 @@ ip_tables
 iptable_filter
 iptable_nat
 EOF
+
+add_host
 
 # robotest might SSH before bootstrap script is complete (and will fail)
 touch /var/lib/bootstrap_complete

--- a/infra/gravity/parse.go
+++ b/infra/gravity/parse.go
@@ -62,18 +62,13 @@ func populateStatus(key, value string, status *GravityStatus) error {
 // 1+0 records in
 // 1+0 records out
 // 1073741824 bytes (1.1 GB) copied, 4.52455 s, 237 MB/s
-func ParseDDOutput(output string) (uint64, error) {
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	if len(lines) != 3 {
-		return 0, trace.BadParameter("expected 3 lines but got %v:\n%v", len(lines), output)
-	}
-
+func ParseDDOutput(output string) (speedBytesPerSec uint64, err error) {
 	// 1073741824 bytes (1.1 GB) copied, 4.52455 s, 237 MB/s
 	// 1073741824 bytes (1,1 GB, 1,0 GiB) copied, 4,53701 s, 237 MB/s
-	testResults := lines[2]
-	match := speedRe.FindStringSubmatch(testResults)
+	output = strings.TrimSpace(output)
+	match := speedRe.FindStringSubmatch(output)
 	if len(match) != 2 {
-		return 0, trace.BadParameter("failed to match speed value (e.g. 237 MB/s) in %q", testResults)
+		return 0, trace.BadParameter("failed to match speed value (e.g. 237 MB/s) in %q", output)
 	}
 
 	// Support comma-formatted floats - depending on selected locale

--- a/infra/gravity/parse_test.go
+++ b/infra/gravity/parse_test.go
@@ -1,0 +1,48 @@
+package gravity
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDOutputParser(t *testing.T) {
+	flag.Parse()
+
+	var testCases = []struct {
+		input       string
+		expectedBps uint64
+		comment     string
+	}{
+		{
+			input: `1024+0 records in
+1024+0 records out
+104857600 bytes (105 MB, 100 MiB) copied, 3.06473 s, 237 MB/s`,
+			expectedBps: 237 * 1000000,
+			comment:     "parses the required value",
+		},
+		{
+			input: `sudo: unable to resolve host node-0
+1024+0 records in
+1024+0 records out
+104857600 bytes (105 MB, 100 MiB) copied, 3.06473 s, 2 GB/s`,
+			expectedBps: 2 * 1000000000,
+			comment:     "ignores unrelevant parts",
+		},
+		{
+			input: `1024+0 records in
+1024+0 records out
+104857600 bytes (105 MB, 100 MiB) copied, 3.06473 s, 2048 kB/s`,
+			expectedBps: 2048 * 1000,
+			comment:     "also handles kilobytes/sec",
+		},
+	}
+
+	for _, testCase := range testCases {
+		bps, err := ParseDDOutput(testCase.input)
+		require.Nil(t, err, testCase.comment)
+		assert.Equal(t, bps, testCase.expectedBps, testCase.comment)
+	}
+}

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -404,13 +404,13 @@ func waitDisks(ctx context.Context, nodes []Gravity, paths []string) error {
 // waitDisk will wait specific disk performance to report OK
 func waitDisk(ctx context.Context, node Gravity, paths []string, minSpeed uint64) error {
 	err := wait.Retry(ctx, func() error {
-		for _, p := range paths {
-			if !strings.HasPrefix(p, "/dev") {
-				defer sshutil.Run(ctx, node.Client(), node.Logger(), fmt.Sprintf("sudo /bin/rm -f %s", p), nil)
+		for _, path := range paths {
+			if !strings.HasPrefix(path, "/dev") {
+				defer sshutil.Run(ctx, node.Client(), node.Logger(), fmt.Sprintf("sudo /bin/rm -f %s", path), nil)
 			}
 			var out string
 			_, err := sshutil.RunAndParse(ctx, node.Client(), node.Logger(),
-				fmt.Sprintf("sudo dd if=/dev/zero of=%s bs=100K count=1024 conv=fdatasync 2>&1", p),
+				fmt.Sprintf("sudo dd if=/dev/zero of=%s bs=100K count=1024 conv=fdatasync 2>&1", path),
 				nil, sshutil.ParseAsString(&out))
 			if err != nil {
 				return wait.Abort(trace.Wrap(err))
@@ -421,7 +421,7 @@ func waitDisk(ctx context.Context, node Gravity, paths []string, minSpeed uint64
 			}
 			if speed < minSpeed {
 				return wait.Continue(fmt.Sprintf("%s has %v/s < minimum of %v/s",
-					p, humanize.Bytes(speed), humanize.Bytes(minSpeed)))
+					path, humanize.Bytes(speed), humanize.Bytes(minSpeed)))
 			}
 		}
 		return nil


### PR DESCRIPTION
Relax `ParseDDOutput` to allow lose output (and avoid hiccups whenever "dd" is used with tools like sudo).

Map hostname to localhost in /etc/hosts to avoid
```
sudo: unable to resolve hostname
```
errors.