### PR TITLE
Do not abort test on non-final operation state

### DIFF
--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -140,7 +140,7 @@ func waitFileInstaller(ctx context.Context, file string, logger log.FieldLogger)
 			return nil
 		}
 		if os.IsNotExist(err) {
-			return wait.Continue(fmt.Sprintf("waiting for installer file %s", file))
+			return wait.Continue("waiting for installer file %s", file)
 			logger.Warn("waiting for installer file to become available")
 		}
 		return wait.Abort(trace.ConvertSystemError(err))

--- a/infra/gravity/cluster_resize.go
+++ b/infra/gravity/cluster_resize.go
@@ -56,9 +56,9 @@ func waitEtcdHealthOk(ctx context.Context, node Gravity) func() error {
 		}
 
 		if exitCode > 0 {
-			return wait.ContinueRetry{err.Error()}
+			return wait.Continue(err.Error())
 		} else {
-			return wait.AbortRetry{err}
+			return wait.Abort(err)
 		}
 	}
 }

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -454,7 +454,7 @@ func (g *gravity) runOp(ctx context.Context, command string) error {
 		case opStatusFailed:
 			return wait.Abort(trace.Errorf("%s: response=%s, err=%v", cmd, response, err))
 		default:
-			return trace.BadParameter("non-final / unknown op status: %q", response)
+			return wait.Continue("non-final / unknown op status: %q", response)
 		}
 	})
 	return trace.Wrap(err)

--- a/infra/gravity/node_utils.go
+++ b/infra/gravity/node_utils.go
@@ -2,7 +2,6 @@ package gravity
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	"github.com/gravitational/robotest/lib/wait"
@@ -81,8 +80,8 @@ func doRelocate(ctx context.Context, g Gravity) error {
 	}
 
 	if newMaster.NodeIP == master.NodeIP {
-		return wait.Continue(fmt.Sprintf(
-			"new master %+v was elected on same node as old %+v", newMaster, master))
+		return wait.Continue(
+			"new master %+v was elected on same node as old %+v", newMaster, master)
 	}
 
 	return nil

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -429,8 +429,8 @@ func waitDisk(ctx context.Context, node Gravity, paths []string, minSpeed uint64
 				return wait.Abort(trace.Wrap(err))
 			}
 			if speed < minSpeed {
-				return wait.Continue(fmt.Sprintf("%s has %v/s < minimum of %v/s",
-					path, humanize.Bytes(speed), humanize.Bytes(minSpeed)))
+				return wait.Continue("%s has %v/s < minimum of %v/s",
+					path, humanize.Bytes(speed), humanize.Bytes(minSpeed))
 			}
 		}
 		return nil

--- a/lib/ssh/files.go
+++ b/lib/ssh/files.go
@@ -91,7 +91,7 @@ func WaitForFile(ctx context.Context, client *ssh.Client, log logrus.FieldLogger
 		}
 
 		if trace.IsNotFound(err) {
-			return wait.Continue(fmt.Sprintf("test %s %s false", path, test))
+			return wait.Continue("test %s %s false", path, test)
 		}
 
 		return wait.Abort(trace.Wrap(err, "waiting for %s", path))

--- a/lib/ssh/time.go
+++ b/lib/ssh/time.go
@@ -3,7 +3,6 @@ package sshutils
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
@@ -69,7 +68,7 @@ func checkTimeInSync(ctx context.Context, nodes []SshNode) func() error {
 			return nil
 		}
 
-		return wait.ContinueRetry{fmt.Sprintf("not all system clocks updated with NTP: %v", values)}
+		return wait.Continue("not all system clocks updated with NTP: %v", values)
 	}
 }
 

--- a/lib/wait/retry.go
+++ b/lib/wait/retry.go
@@ -13,12 +13,13 @@ import (
 
 // Abort causes Retry function to stop with error
 func Abort(err error) AbortRetry {
-	return AbortRetry{err}
+	return AbortRetry{Err: err}
 }
 
 // Continue causes Retry function to continue trying and logging message
-func Continue(message string) ContinueRetry {
-	return ContinueRetry{message}
+func Continue(format string, args ...interface{}) ContinueRetry {
+	message := fmt.Sprintf(format, args...)
+	return ContinueRetry{Message: message}
 }
 
 // AbortRetry if returned from Retry, will lead to retries to be stopped,


### PR DESCRIPTION
 * Do not report non-final operation status as `trace.BadParameter` to avoid confusing the test retry loop [here](https://github.com/gravitational/robotest/blob/400cf792b151bb3c152433a3f2753eed2142e233/infra/gravity/testsuite.go#L197) and give the test the allotted number of retries in case of previous failures.
 * Simplify lib/wait.Continue API to support formatting.