### PR TITLE
Add couple install parameters.

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -97,6 +97,10 @@ type InstallParam struct {
 	OSFlavor OS `json:"os" validate:"required"`
 	// DockerStorageDriver is one of supported storage drivers
 	DockerStorageDriver StorageDriver `json:"storage_driver"`
+	// InstallerURL overrides installer URL from the global config
+	InstallerURL string `json:"installer_url,omitempty"`
+	// OpsAdvertiseAddr is optional Ops Center advertise address to pass to the install command
+	OpsAdvertiseAddr string `json:"ops_advertise_addr,omitempty"`
 }
 
 // JoinCmd represents various parameters for Join
@@ -220,7 +224,8 @@ var installCmdTemplate = template.Must(
 		{{if .StorageDriver}}--storage-driver={{.StorageDriver}}{{end}} \
 		--system-log-file=./telekube-system.log \
 		--cloud-provider={{.CloudProvider}} --state-dir={{.StateDir}} \
-		{{if .Cluster}}--cluster={{.Cluster}}{{end}}
+		{{if .Cluster}}--cluster={{.Cluster}}{{end}} \
+		{{if .OpsAdvertiseAddr}}--ops-advertise-addr={{.OpsAdvertiseAddr}}{{end}}
 `))
 
 // Status queries cluster status

--- a/suite/sanity/install.go
+++ b/suite/sanity/install.go
@@ -43,7 +43,12 @@ func install(p interface{}) (gravity.TestFunc, error) {
 		g.OK("VMs ready", err)
 		defer destroyFn()
 
-		g.OK("installer downloaded", g.SetInstaller(nodes, cfg.InstallerURL, "install"))
+		installerURL := cfg.InstallerURL
+		if param.InstallerURL != "" {
+			installerURL = param.InstallerURL
+		}
+
+		g.OK("installer downloaded", g.SetInstaller(nodes, installerURL, "install"))
 		if param.Script != nil {
 			g.OK("post bootstrap script",
 				g.ExecScript(nodes, param.Script.Url, param.Script.Args))
@@ -63,6 +68,11 @@ func provision(p interface{}) (gravity.TestFunc, error) {
 		g.OK("provision nodes", err)
 		defer destroyFn()
 
-		g.OK("download installer", g.SetInstaller(nodes, cfg.InstallerURL, "install"))
+		installerURL := cfg.InstallerURL
+		if param.InstallerURL != "" {
+			installerURL = param.InstallerURL
+		}
+
+		g.OK("download installer", g.SetInstaller(nodes, installerURL, "install"))
 	}, nil
 }


### PR DESCRIPTION
* Allow passing installer URL via install parameters to override global one.
* Add support for `--ops-advertise-addr` install flag.