### PR TITLE
Dmitri/3826 detect preempt

### DIFF
--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -35,7 +35,7 @@ func (c *TestContext) SetInstaller(nodes []Gravity, installerUrl string, tag str
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.WaitForInstaller)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.WaitForInstaller)
 	defer cancel()
 
 	err := waitFileInstaller(ctx, installerUrl, c.Logger())
@@ -43,7 +43,7 @@ func (c *TestContext) SetInstaller(nodes []Gravity, installerUrl string, tag str
 		return trace.Wrap(err)
 	}
 
-	ctx, cancel = context.WithTimeout(c.parent, c.timeouts.Install)
+	ctx, cancel = context.WithTimeout(c.ctx, c.timeouts.Install)
 	defer cancel()
 
 	errs := make(chan error, len(nodes))
@@ -70,7 +70,7 @@ func (c *TestContext) OfflineInstall(nodes []Gravity, param InstallParam) error 
 
 	c.Logger().Info("Offline install.")
 
-	ctx, cancel := context.WithTimeout(c.parent, withDuration(c.timeouts.Install, len(nodes)))
+	ctx, cancel := context.WithTimeout(c.ctx, withDuration(c.timeouts.Install, len(nodes)))
 	defer cancel()
 
 	param.CloudProvider = c.provisionerCfg.CloudProvider
@@ -151,7 +151,7 @@ func waitFileInstaller(ctx context.Context, file string, logger log.FieldLogger)
 // Uninstall makes nodes leave cluster and uninstall gravity
 // it is not asserting internally
 func (c *TestContext) Uninstall(nodes []Gravity) error {
-	ctx, cancel := context.WithTimeout(c.parent, withDuration(c.timeouts.Install, len(nodes)))
+	ctx, cancel := context.WithTimeout(c.ctx, withDuration(c.timeouts.Install, len(nodes)))
 	defer cancel()
 
 	errs := make(chan error, len(nodes))
@@ -194,7 +194,7 @@ func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, subdir string) erro
 	log := c.Logger().WithField("leader", master)
 	log.Info("Pull installer.")
 
-	ctx, cancel := context.WithTimeout(c.parent, withDuration(c.timeouts.Install, len(nodes)))
+	ctx, cancel := context.WithTimeout(c.ctx, withDuration(c.timeouts.Install, len(nodes)))
 	defer cancel()
 
 	err = master.SetInstaller(ctx, installerUrl, subdir)
@@ -208,7 +208,7 @@ func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, subdir string) erro
 		return trace.Wrap(err)
 	}
 
-	ctx, cancel = context.WithTimeout(c.parent, withDuration(c.timeouts.Upgrade, len(nodes)))
+	ctx, cancel = context.WithTimeout(c.ctx, withDuration(c.timeouts.Upgrade, len(nodes)))
 	defer cancel()
 
 	log.Info("Upgrade.")
@@ -218,7 +218,7 @@ func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, subdir string) erro
 
 // ExecScript will run and execute a script on all nodes
 func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []string) error {
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
 
 	errs := make(chan error, len(nodes))

--- a/infra/gravity/cluster_resize.go
+++ b/infra/gravity/cluster_resize.go
@@ -23,7 +23,7 @@ func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
 		"extra":   extra,
 	}).Info("Expand.")
 
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
 
 	master := current[0]
@@ -33,7 +33,7 @@ func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
 		return trace.Wrap(err, "query status from [%v]", master)
 	}
 
-	ctx, cancel = context.WithTimeout(c.parent, withDuration(c.timeouts.Install, len(extra)))
+	ctx, cancel = context.WithTimeout(c.ctx, withDuration(c.timeouts.Install, len(extra)))
 	defer cancel()
 
 	for _, node := range extra {
@@ -54,7 +54,7 @@ func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
 
 // ShrinkLeave will gracefully leave cluster
 func (c *TestContext) ShrinkLeave(nodesToKeep, nodesToRemove []Gravity) error {
-	ctx, cancel := context.WithTimeout(c.parent, withDuration(c.timeouts.Leave, len(nodesToRemove)))
+	ctx, cancel := context.WithTimeout(c.ctx, withDuration(c.timeouts.Leave, len(nodesToRemove)))
 	defer cancel()
 
 	errs := make(chan error, len(nodesToRemove))
@@ -76,7 +76,7 @@ func (c *TestContext) RemoveNode(nodesToKeep []Gravity, remove Gravity) error {
 
 	master := nodesToKeep[0]
 
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Leave)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Leave)
 	defer cancel()
 
 	err := master.Remove(ctx, remove.Node().PrivateAddr(), Graceful(!remove.Offline()))

--- a/infra/gravity/cluster_status.go
+++ b/infra/gravity/cluster_status.go
@@ -14,7 +14,7 @@ import (
 // Status walks around all nodes and checks whether they all feel OK
 func (c *TestContext) Status(nodes []Gravity) error {
 	c.Logger().WithField("nodes", Nodes(nodes)).Info("Check status on nodes.")
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
 
 	retry := wait.Retryer{
@@ -53,7 +53,7 @@ func (c *TestContext) CheckTimeSync(nodes []Gravity) error {
 		})
 	}
 
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
 
 	err := sshutils.CheckTimeSync(ctx, timeNodes)
@@ -63,7 +63,7 @@ func (c *TestContext) CheckTimeSync(nodes []Gravity) error {
 // PullLogs requests logs from all nodes
 // prefix `postmortem` is reserved for cleanup procedure
 func (c *TestContext) CollectLogs(prefix string, nodes []Gravity) error {
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.CollectLogs)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.CollectLogs)
 	defer cancel()
 
 	errs := make(chan error, len(nodes))
@@ -105,7 +105,7 @@ func (c *TestContext) NodesByRole(nodes []Gravity) (*ClusterNodesByRole, error) 
 
 	roles := ClusterNodesByRole{}
 
-	ctx, cancel := context.WithTimeout(c.parent, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
 
 	apiMaster, err := ResolveInPlanet(ctx, nodes[0], apiserver)

--- a/infra/gravity/node_utils.go
+++ b/infra/gravity/node_utils.go
@@ -46,7 +46,7 @@ func doRelocate(ctx context.Context, g Gravity) error {
 		}
 	}
 	if master == nil {
-		return wait.Abort(trace.Errorf("no current cluster master: %+v", pods))
+		return wait.Abort(trace.NotFound("no current cluster master: %+v", pods))
 	}
 
 	if err = KubectlDeletePod(ctx, g, kubeSystemNS, master.Name); err != nil {

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -277,6 +277,7 @@ func (c *TestContext) postProvision(cfg ProvisionerConfig, gravityNodes []Gravit
 					}
 					// Consider the abort to be an indication of node preemption and
 					// cancel the test
+					c.Logger().Infof("Node %v was stopped/preempted, cancelling test.", node)
 					c.cancel()
 				case utils.IsContextCancelledError(err):
 					// Ignore

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -278,6 +278,8 @@ func (c *TestContext) postProvision(cfg ProvisionerConfig, gravityNodes []Gravit
 					// Consider the abort to be an indication of node preemption and
 					// cancel the test
 					c.cancel()
+				case utils.IsContextCancelledError(err):
+					// Ignore
 				default:
 					c.Logger().Warnf("Failed to stream logs: %v.", err)
 				}

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -258,7 +258,7 @@ func (c *TestContext) provisionCloud(cfg ProvisionerConfig) (cluster Cluster, co
 	log.WithField("nodes", gravityNodes).Debug("Provisioning complete")
 
 	cluster.Nodes = gravityNodes
-	cluster.Destroy = wrapDestroyFn(c, cfg.Tag(), gravityNodes, infra.destroyFn)
+	cluster.Destroy = wrapDestroyFunc(c, cfg.Tag(), gravityNodes, infra.destroyFn)
 
 	return cluster, &infra.params.terraform, nil
 }

--- a/infra/gravity/terraform.go
+++ b/infra/gravity/terraform.go
@@ -44,9 +44,9 @@ var testStatus = map[bool]string{true: "failed", false: "ok"}
 
 const finalTeardownTimeout = time.Minute * 5
 
-// wrapDestroyFn returns a function that wraps the specified set of nodes and the given clean up function
-// that implements report collection and resource clean up.
-func wrapDestroyFn(c *TestContext, tag string, nodes []Gravity, destroy func(context.Context) error) DestroyFn {
+// wrapDestroyFunc returns a function that wraps the specified set of nodes
+// and the given clean up function that implements report collection and resource clean up.
+func wrapDestroyFunc(c *TestContext, tag string, nodes []Gravity, destroy func(context.Context) error) DestroyFn {
 	return func() error {
 		defer func() {
 			if r := recover(); r != nil {
@@ -90,6 +90,9 @@ func wrapDestroyFn(c *TestContext, tag string, nodes []Gravity, destroy func(con
 			log.Info("not destroying VMs per policy")
 			return nil
 		}
+
+		// Close the monitor processes
+		c.monitorCancel()
 
 		log.Info("destroying VMs")
 

--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -246,6 +246,7 @@ func (s *testSuite) runTestFunc(t *testing.T, testFunc TestFunc, cfg Provisioner
 	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 	monitorCtx, monitorCancel := context.WithCancel(ctx)
+	defer monitorCancel()
 
 	testCtx := &TestContext{
 		name:     cfg.Tag(),

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -48,3 +48,9 @@ func Collect(ctx context.Context, cancel func(), errChan chan error, valuesChan 
 
 	return values, trace.NewAggregate(errors...)
 }
+
+// IsContextCancelledError returns true if the given error
+// is a context cancelled error
+func IsContextCancelledError(err error) bool {
+	return trace.Unwrap(err) == context.Canceled
+}

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -84,8 +84,8 @@ func TestMain(t *testing.T) {
 
 	// testing package has internal 10 mins timeout, can be reset from command line only
 	// see docker/suite/entrypoint.sh
-	ctx, cancelFn := context.WithTimeout(context.Background(), testMaxTime)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), testMaxTime)
+	defer cancel()
 
 	policy := gravity.ProvisionerPolicy{
 		DestroyOnSuccess:  *destroyOnSuccess,


### PR DESCRIPTION
Add basic support for detection of node preemption by restarting the test faster than during the usual operation.