### PR TITLE
Dmitri/3825 report

### DIFF
--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -10,10 +10,10 @@ if [ -d $(dirname ${INSTALLER_URL}) ]; then
 	EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${INSTALLER_URL}):$(dirname ${INSTALLER_FILE})
 fi
 
-# TEST_OS could be "ubuntu,centos,redhat"
-# STORAGE_DRIVER could be "devicemapper,loopback,overlay,overlay2"
-TEST_OS=${TEST_OS:-ubuntu}
-STORAGE_DRIVER=${STORAGE_DRIVER:-overlay2}
+# GRAVTIY_FILE/GRAVITY_URL specify the location of the up-to-date gravity binary
+if [ -d $(dirname ${GRAVITY_URL}) ]; then
+	GRAVITY_FILE='/installer/'$(basename ${GRAVITY_URL})
+fi
 
 REPEAT_TESTS=${REPEAT_TESTS:-1}
 PARALLEL_TESTS=${PARALLEL_TESTS:-1}
@@ -115,6 +115,7 @@ fi
 
 CLOUD_CONFIG="
 installer_url: ${INSTALLER_FILE:-${INSTALLER_URL}}
+gravity_url: ${GRAVITY_FILE:-${GRAVITY_URL}}
 script_path: /robotest/terraform/${DEPLOY_TO}
 state_dir: /robotest/state
 cloud: ${DEPLOY_TO}

--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -6,13 +6,14 @@ set -eu -o pipefail
 #
 
 if [ -d $(dirname ${INSTALLER_URL}) ]; then
-	INSTALLER_FILE='/installer/'$(basename ${INSTALLER_URL})
-	EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${INSTALLER_URL}):$(dirname ${INSTALLER_FILE})
+  INSTALLER_FILE='/installer/'$(basename ${INSTALLER_URL})
+  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "${INSTALLER_URL}:${INSTALLER_FILE}
 fi
 
 # GRAVTIY_FILE/GRAVITY_URL specify the location of the up-to-date gravity binary
 if [ -d $(dirname ${GRAVITY_URL}) ]; then
-	GRAVITY_FILE='/installer/'$(basename ${GRAVITY_URL})
+  GRAVITY_FILE='/installer/'$(basename ${GRAVITY_URL})
+  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "${GRAVITY_URL}:${GRAVITY_FILE}
 fi
 
 REPEAT_TESTS=${REPEAT_TESTS:-1}

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -240,15 +240,15 @@ func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []strin
 }
 
 func uploadBinaries(ctx context.Context, nodes []Gravity, url, subdir string) error {
-	errors := make(chan error, len(nodes)-1)
+	errs := make(chan error, len(nodes)-1)
 	for _, node := range nodes {
 		go func(node Gravity) {
 			err := node.TransferFile(ctx, url, subdir)
-			errors <- trace.Wrap(err)
+			errs <- trace.Wrap(err)
 		}(node)
 	}
 
-	err := utils.CollectErrors(ctx, errors)
+	err := utils.CollectErrors(ctx, errs)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -184,7 +184,7 @@ func (c *TestContext) UninstallApp(nodes []Gravity) error {
 }
 
 // Upgrade tries to perform an upgrade procedure on all nodes
-func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, subdir string) error {
+func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, gravityURL, subdir string) error {
 	roles, err := c.NodesByRole(nodes)
 	if err != nil {
 		return trace.Wrap(err)
@@ -208,6 +208,14 @@ func (c *TestContext) Upgrade(nodes []Gravity, installerUrl, subdir string) erro
 		return trace.Wrap(err)
 	}
 
+	if len(nodes) > 1 {
+		log.Info("Upload gravity binaries.")
+		err = uploadBinaries(ctx, roles.Other, gravityURL, subdir)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
 	ctx, cancel = context.WithTimeout(c.ctx, withDuration(c.timeouts.Upgrade, len(nodes)))
 	defer cancel()
 
@@ -229,4 +237,21 @@ func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []strin
 	}
 
 	return trace.Wrap(utils.CollectErrors(ctx, errs))
+}
+
+func uploadBinaries(ctx context.Context, nodes []Gravity, url, subdir string) error {
+	errors := make(chan error, len(nodes)-1)
+	for _, node := range nodes {
+		go func(node Gravity) {
+			err := node.TransferFile(ctx, url, subdir)
+			errors <- trace.Wrap(err)
+		}(node)
+	}
+
+	err := utils.CollectErrors(ctx, errors)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }

--- a/infra/gravity/cluster_status.go
+++ b/infra/gravity/cluster_status.go
@@ -24,16 +24,16 @@ func (c *TestContext) Status(nodes []Gravity) error {
 	}
 
 	err := retry.Do(ctx, func() error {
-		errors := make(chan error, len(nodes))
+		errs := make(chan error, len(nodes))
 
 		for _, node := range nodes {
 			go func(n Gravity) {
 				_, err := n.Status(ctx)
-				errors <- err
+				errs <- err
 			}(node)
 		}
 
-		err := utils.CollectErrors(ctx, errors)
+		err := utils.CollectErrors(ctx, errs)
 		if err == nil {
 			return nil
 		}
@@ -66,7 +66,7 @@ func (c *TestContext) CheckTimeSync(nodes []Gravity) error {
 func (c *TestContext) CollectLogs(prefix string, nodes []Gravity) error {
 	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.CollectLogs)
 	defer cancel()
-	errors := make(chan error, len(nodes))
+	errs := make(chan error, len(nodes))
 
 	api, other, err := apiserverNode(ctx, nodes)
 	if err != nil {
@@ -87,11 +87,11 @@ func (c *TestContext) CollectLogs(prefix string, nodes []Gravity) error {
 			} else {
 				n.Logger().WithError(err).Error("Failed to fetch node logs.")
 			}
-			errors <- err
+			errs <- err
 		}(i, node)
 	}
 
-	return trace.Wrap(utils.CollectErrors(ctx, errors))
+	return trace.Wrap(utils.CollectErrors(ctx, errs))
 }
 
 // ClusterNodesByRole defines which roles every node plays in a cluster

--- a/infra/gravity/config.go
+++ b/infra/gravity/config.go
@@ -82,10 +82,10 @@ type ProvisionerConfig struct {
 	// ScriptPath is the path to the terraform script or directory for provisioning
 	ScriptPath string `yaml:"script_path" validate:"required"`
 	// InstallerURL specifies the location of the installer tarball.
-	// Can either a local path or S3 URL
+	// Can either be a local path or S3 URL
 	InstallerURL string `yaml:"installer_url" validate:"required"`
 	// GravityURL specifies the location of the up-to-date gravity binary.
-	// Can either a local path or S3 URL
+	// Can either be a local path or S3 URL
 	GravityURL string `yaml:"gravity_url" validate:"required"`
 	// StateDir defines base directory where to keep state (i.e. terraform configs/vars)
 	StateDir string `yaml:"state_dir" validate:"required"`

--- a/infra/gravity/config.go
+++ b/infra/gravity/config.go
@@ -81,8 +81,12 @@ type ProvisionerConfig struct {
 
 	// ScriptPath is the path to the terraform script or directory for provisioning
 	ScriptPath string `yaml:"script_path" validate:"required"`
-	// InstallerURL is AWS S3 URL with the installer
+	// InstallerURL specifies the location of the installer tarball.
+	// Can either a local path or S3 URL
 	InstallerURL string `yaml:"installer_url" validate:"required"`
+	// GravityURL specifies the location of the up-to-date gravity binary.
+	// Can either a local path or S3 URL
+	GravityURL string `yaml:"gravity_url" validate:"required"`
 	// StateDir defines base directory where to keep state (i.e. terraform configs/vars)
 	StateDir string `yaml:"state_dir" validate:"required"`
 

--- a/lib/ssh/scp.go
+++ b/lib/ssh/scp.go
@@ -68,6 +68,9 @@ func PutFile(ctx context.Context, client *ssh.Client, log logrus.FieldLogger, sr
 	}
 
 	if err != nil {
+		if IsExitMissingError(err) {
+			log.WithError(err).Warn("Session aborted unexpectedly (node destroyed?).")
+		}
 		return "", trace.Wrap(err)
 	}
 

--- a/suite/sanity/upgrade.go
+++ b/suite/sanity/upgrade.go
@@ -36,7 +36,7 @@ func upgrade(p interface{}) (gravity.TestFunc, error) {
 		g.OK("base installer", g.SetInstaller(cluster.Nodes, param.BaseInstallerURL, "base"))
 		g.OK("install", g.OfflineInstall(cluster.Nodes, param.InstallParam))
 		g.OK("status", g.Status(cluster.Nodes))
-		g.OK("upgrade", g.Upgrade(cluster.Nodes, cfg.InstallerURL, "upgrade"))
+		g.OK("upgrade", g.Upgrade(cluster.Nodes, cfg.InstallerURL, cfg.GravityURL, "upgrade"))
 		g.OK("status", g.Status(cluster.Nodes))
 	}, nil
 }


### PR DESCRIPTION
This PR adds an additional configuration attribute to specify the location of the tested gravity binary to upload to nodes during upgrade.
Now, robotest would only upload the update tarball to a single node it used to launch the upgrade from. After the tests, it used the gravity binaries from the base version on all other nodes to collect debug reports. This obviously has issues if report collection was improved or fixed bugs in the tested version versus the base version (the one used as a basis for upgrade).

In this PR, robotest will also upload the tested gravity binary to nodes other than the one hosting the update tarball before the test to collect debug reports using the up-to-date binary. The reason this is not instead using, for example, the binary as extracted by the agents is being able to capture logs even in the unlikely event of upgrade failing to start.
Additionally, debug logs collection was optimized to only collect kubernetes logs from a single master node to avoid redundant captures (and significantly cut down on time for collecting logs depending on the cluster size).

Fixes https://github.com/gravitational/gravity.e/issues/3825.