### PR TITLE
Revert to old behavior for installer_url volume

### DIFF
--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -7,13 +7,13 @@ set -eu -o pipefail
 
 if [ -d $(dirname ${INSTALLER_URL}) ]; then
   INSTALLER_FILE='/installer/'$(basename ${INSTALLER_URL})
-  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "${INSTALLER_URL}:${INSTALLER_FILE}
+  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${INSTALLER_URL}):$(dirname ${INSTALLER_FILE})
 fi
 
 # GRAVTIY_FILE/GRAVITY_URL specify the location of the up-to-date gravity binary
 if [ -d $(dirname ${GRAVITY_URL}) ]; then
   GRAVITY_FILE='/installer/'$(basename ${GRAVITY_URL})
-  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "${GRAVITY_URL}:${GRAVITY_FILE}
+  EXTRA_VOLUME_MOUNTS=${EXTRA_VOLUME_MOUNTS:-}" -v "$(dirname ${GRAVITY_URL}):$(dirname ${GRAVITY_FILE})
 fi
 
 REPEAT_TESTS=${REPEAT_TESTS:-1}


### PR DESCRIPTION
Expose the directories of corresponding `INSTALLER_URL` / `GRAVITY_URL` (i.e. keep old behavior) as docker volumes as opposed to exposing the file paths as this breaks the use-case of implicit `INSTALL_URL` override in a test that references a new file from the build directory.