### PR TITLE
Run update unattended

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -531,7 +531,7 @@ const (
 func (g *gravity) runOp(ctx context.Context, command string, env map[string]string) error {
 	var code string
 	err := sshutils.RunAndParse(ctx, g.Client(), g.Logger(),
-		fmt.Sprintf(`cd %s && sudo -E ./gravity %s --insecure --quiet --system-log-file=./telekube-system.log`,
+		fmt.Sprintf(`sh -c "cd %s && sudo -E ./gravity %s --insecure --quiet --system-log-file=./telekube-system.log"`,
 			g.installDir, command),
 		env, sshutils.ParseAsString(&code))
 	if err != nil {

--- a/lib/ssh/run_parse.go
+++ b/lib/ssh/run_parse.go
@@ -168,7 +168,7 @@ func ParseAsString(out *string) OutputParseFn {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		*out = strings.Replace(string(b), `\r`, ``, -1)
+		*out = string(bytes.TrimSpace(b))
 		return nil
 	}
 }


### PR DESCRIPTION
This PR adds the option for robotest to run unattended updates for 5.4 (where the update mode has been flipped to be blocking by default).
This does not break other versions though as the blocking mode is controlled via an environment variable.