### PR TITLE
Use full URLs for logs

### DIFF
--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -166,10 +166,8 @@ severity>=INFO`, testUID, s.uid)},
 		}.Encode(),
 	}
 
-	// Google UIRL shortener has been discontinued.
+	// Google URL shortener has been discontinued.
 	// See https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html for details.
-	// short, err := s.client.Shorten(s.ctx, longUrl.String())
-	// return short, trace.Wrap(err)
 	// TODO(dmitri): decide whether it would make sense to migrate to Firebase Dynamic Links as a replacement.
 	// For now, return full URLs
 	return longUrl.String(), nil

--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -163,10 +163,16 @@ func (s *testSuite) getLogLink(testUID string) (string, error) {
 labels.__uuid__="%s"
 labels.__suite__="%s"
 severity>=INFO`, testUID, s.uid)},
-		}.Encode()}
+		}.Encode(),
+	}
 
-	short, err := s.client.Shorten(s.ctx, longUrl.String())
-	return short, trace.Wrap(err)
+	// Google UIRL shortener has been discontinued.
+	// See https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html for details.
+	// short, err := s.client.Shorten(s.ctx, longUrl.String())
+	// return short, trace.Wrap(err)
+	// TODO(dmitri): decide whether it would make sense to migrate to Firebase Dynamic Links as a replacement.
+	// For now, return full URLs
+	return longUrl.String(), nil
 }
 
 func (s *testSuite) wrap(fn TestFunc, baseConfig ProvisionerConfig, param interface{}) func(t *testing.T) {

--- a/lib/xlog/shorten.go
+++ b/lib/xlog/shorten.go
@@ -20,6 +20,9 @@ type shortenerMsg struct {
 	Kind  string `json:"kind,omitempty"`
 }
 
+// Google URL shortener has been discontinued.
+// See https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html for details.
+// TODO(dmitri): remove or update to use another service
 func (c GCLClient) Shorten(ctx context.Context, url string) (short string, err error) {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
Remove shortening of log URLs as the service we were using was discontinued - return full URLs at the moment. This needs to be decided later whether to migrate to Firebase Dynamic Links (i.e. stay with google) or use other URL service or do completely away with shorterning.
