### PR TITLE
Fix debian/ubuntu bootstrap w.r.t existing user

### DIFF
--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -38,7 +38,7 @@ function setup-user {
 
   if [ -z "$service_uid" ]; then
     service_uid=1000
-    useradd --system --non-unique -g $service_gid -u $service_uid ${os_user}
+    (useradd --system --non-unique --gid $service_gid --uid $service_uid ${os_user} 2>/dev/null; err=$?; if (( $err != 9 )); then exit $err; fi) || true
   fi
 
   if [ ! -d "/home/${os_user}/.ssh" ]; then

--- a/infra/gravity/terraform.go
+++ b/infra/gravity/terraform.go
@@ -42,7 +42,7 @@ func SetProvisionerPolicy(p ProvisionerPolicy) {
 
 var testStatus = map[bool]string{true: "failed", false: "ok"}
 
-const finalTeardownTimeout = time.Minute * 5
+const finalTeardownTimeout = 20 * time.Minute
 
 // wrapDestroyFunc returns a function that wraps the specified set of nodes
 // and the given clean up function that implements report collection and resource clean up.


### PR DESCRIPTION
 * Bump teardown timeout to 20m.
 * Fix ubuntu/debian bootstrap script to account for existing user.