### PR TITLE
Fix corrupted go.mod/go.sum timestamp.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-playground/universal-translator v0.0.0-20170327191703-71201497bace // indirect
 	github.com/googleapis/gax-go v0.0.0-20181202182837-5d9b035a0f09 // indirect
 	github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23
-	github.com/gravitational/trace v0.0.0-20190626162700-a535a178675f
+	github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f
 	github.com/hashicorp/go-version v1.0.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/jonboulle/clockwork v0.0.0-20180716110948-e7c6d408fd5c // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/googleapis/gax-go/v2 v2.0.2 h1:/rNgUniLy2vDXiK2xyJOcirGpC3G99dtK1NWx2
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23 h1:havbccuFO5fRj0O67oHXI7doShLig3rSIXfMrd/UnkA=
 github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23/go.mod h1:XL9nebvlfNVvRzRPWdDcWootcyA0l7THiH/A+W1233g=
-github.com/gravitational/trace v0.0.0-20190626162700-a535a178675f h1:n7wK/5ShjZz3gSX5Ds1Y490DMsjTlNAwKtehddk61lM=
-github.com/gravitational/trace v0.0.0-20190626162700-a535a178675f/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
+github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f h1:68WxnfBzJRYktZ30fmIjGQ74RsXYLoeH2/NITPktTMY=
+github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=


### PR DESCRIPTION
With the current gravitational/trace timestamp in the repo, I was seeing
the following error for most go operations in the Robotest repo:

    $ go mod vendor
    go: github.com/gravitational/trace@v0.0.0-20190626162700-a535a178675f: invalid pseudo-version: does not match version-control timestamp (2019-07-26T14:27:06Z)

I discovered this was because the timestamp in the go.mod/go.sum did not
match the timestamp on the following commit:

    https://github.com/gravitational/trace/commit/a535a178675fb4a11ba74818491754a8c5575dd6

Correcting this addressed the issue for me.

Testing Done:
before
```
walt@work:~/git/robotest$ go mod vendor
go: github.com/gravitational/trace@v0.0.0-20190626162700-a535a178675f: invalid pseudo-version: does not match version-control timestamp (2019-07-26T14:27:06Z)
```
after:
```
walt@work:~/git/robotest$ go mod vendor
go: downloading github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f
go: extracting github.com/gravitational/trace v0.0.0-20190726142706-a535a178675f
```