### PR TITLE
Copyall fix

### DIFF
--- a/lib/system/file_test.go
+++ b/lib/system/file_test.go
@@ -77,20 +77,27 @@ func TestCopyAllDirDstAbsent(t *testing.T) {
 	}
 }
 
-func TestCopyAllFileDstPresent(t *testing.T) {
+// populates a test workspace (tmp) with a src file
+func createSourceFile(t *testing.T) (tmp, src string, fcount int, err error) {
 	// create a workspace
-	tmp, err := ioutil.TempDir("", "robotest-test")
+	tmp, err = ioutil.TempDir("", "robotest-test")
 	if err != nil {
 		t.Skipf("unable to create tempdir: %s", err)
 	}
-	defer os.RemoveAll(tmp)
 
 	// create source file
-	fcount := 1
-	src := filepath.Join(tmp, "/src")
+	fcount = 1
+	src = filepath.Join(tmp, "/src")
 	if err = ioutil.WriteFile(src, []byte("data"), 0640); err != nil {
 		t.Skipf("unable to write to %s: %s", src, err)
 	}
+
+	return tmp, src, fcount, nil
+}
+
+func TestCopyAllFileDstPresent(t *testing.T) {
+	tmp, src, fcount, err := createSourceFile(t)
+	defer os.RemoveAll(tmp)
 
 	// create destination directory
 	dst := filepath.Join(tmp, "/dst")
@@ -110,19 +117,8 @@ func TestCopyAllFileDstPresent(t *testing.T) {
 }
 
 func TestCopyAllFileDstAbsent(t *testing.T) {
-	// create a workspace
-	tmp, err := ioutil.TempDir("", "robotest-test")
-	if err != nil {
-		t.Skipf("unable to create tempdir: %s", err)
-	}
+	tmp, src, fcount, err := createSourceFile(t)
 	defer os.RemoveAll(tmp)
-
-	// create source file
-	fcount := 1
-	src := filepath.Join(tmp, "/src")
-	if err = ioutil.WriteFile(src, []byte("data"), 0640); err != nil {
-		t.Skipf("unable to write to %s: %s", src, err)
-	}
 
 	// no destination directory
 	dst := filepath.Join(tmp, "/dst")

--- a/lib/system/file_test.go
+++ b/lib/system/file_test.go
@@ -1,0 +1,142 @@
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// populates a test workspace (tmp) with a src containing several files
+func createSourceDir(t *testing.T) (tmp, src string, fcount int, err error) {
+	// create a workspace
+	tmp, err = ioutil.TempDir("", "robotest-test")
+	if err != nil {
+		t.Skipf("unable to create tempdir: %s", err)
+	}
+
+	// create content to move, several files to exercise the "all" portion
+	src = filepath.Join(tmp, "/src")
+	err = os.MkdirAll(src, 0750)
+	if err != nil {
+		t.Skipf("unable to create src dir: %s", err)
+	}
+
+	fcount = 3
+	for i := 0; i < fcount; i++ {
+		tmpfile, err := ioutil.TempFile(src, "file")
+		if err != nil {
+			t.Skipf("unable to create tempfile: %s", err)
+		}
+		defer tmpfile.Close()
+		content := []byte("file" + string(i))
+		if _, err := tmpfile.Write(content); err != nil {
+			t.Skipf("unable to write to %s: %s", tmpfile.Name(), err)
+		}
+	}
+	return tmp, src, fcount, nil
+}
+
+func TestCopyAllDirDstPresent(t *testing.T) {
+	tmp, src, fcount, err := createSourceDir(t)
+	defer os.RemoveAll(tmp)
+
+	dst := filepath.Join(tmp, "/dst")
+	err = os.MkdirAll(dst, 0750)
+	if err != nil {
+		t.Skipf("unable to create dst dir: %s", err)
+	}
+
+	var cnt uint
+	err = copyAll(src, dst, &cnt)
+	if err != nil {
+		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
+	}
+	if int(cnt) != fcount {
+		t.Errorf("expected %v files to be copied, only %v copied", fcount, cnt)
+	}
+}
+
+func TestCopyAllDirDstAbsent(t *testing.T) {
+	tmp, src, fcount, err := createSourceDir(t)
+	defer os.RemoveAll(tmp)
+
+	// no destination directory
+	dst := filepath.Join(tmp, "/dst")
+
+	var cnt uint
+	err = copyAll(src, dst, &cnt)
+	if err != nil {
+		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
+	}
+	if int(cnt) != fcount {
+		t.Errorf("expected %v files to be copied, only %v copied", fcount, cnt)
+	}
+	if _, err := os.Stat(dst); os.IsNotExist(err) {
+		t.Errorf("expected %v to be created", dst)
+	}
+}
+
+func TestCopyAllFileDstPresent(t *testing.T) {
+	// create a workspace
+	tmp, err := ioutil.TempDir("", "robotest-test")
+	if err != nil {
+		t.Skipf("unable to create tempdir: %s", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// create source file
+	fcount := 1
+	src := filepath.Join(tmp, "/src")
+	if err = ioutil.WriteFile(src, []byte("data"), 0640); err != nil {
+		t.Skipf("unable to write to %s: %s", src, err)
+	}
+
+	// create destination directory
+	dst := filepath.Join(tmp, "/dst")
+	err = os.MkdirAll(dst, 0750)
+	if err != nil {
+		t.Skipf("unable to create dst dir: %s", err)
+	}
+
+	var cnt uint
+	err = copyAll(src, dst, &cnt)
+	if err != nil {
+		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
+	}
+	if int(cnt) != fcount {
+		t.Errorf("expected %v files to be copied, only %v copied", fcount, cnt)
+	}
+}
+
+func TestCopyAllFileDstAbsent(t *testing.T) {
+	// create a workspace
+	tmp, err := ioutil.TempDir("", "robotest-test")
+	if err != nil {
+		t.Skipf("unable to create tempdir: %s", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// create source file
+	fcount := 1
+	src := filepath.Join(tmp, "/src")
+	if err = ioutil.WriteFile(src, []byte("data"), 0640); err != nil {
+		t.Skipf("unable to write to %s: %s", src, err)
+	}
+
+	// no destination directory
+	dst := filepath.Join(tmp, "/dst")
+
+	var cnt uint
+	err = copyAll(src, dst, &cnt)
+	if err != nil {
+		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
+	}
+	if int(cnt) != fcount {
+		t.Errorf("expected %v files to be copied, only %v copied", fcount, cnt)
+	}
+	if _, err := os.Stat(dst); os.IsNotExist(err) {
+		t.Errorf("expected %v to be created", dst)
+	}
+
+}

--- a/lib/system/file_test.go
+++ b/lib/system/file_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 // populates a test workspace (tmp) with a src containing several files
-func createSourceDir(t *testing.T) (tmp, src string, fcount int, err error) {
+func createSourceDir(t *testing.T) (tmp, src string, fcount int) {
 	// create a workspace
-	tmp, err = ioutil.TempDir("", "robotest-test")
+	tmp, err := ioutil.TempDir("", "robotest-test")
 	if err != nil {
 		t.Skipf("unable to create tempdir: %s", err)
 	}
@@ -34,15 +34,15 @@ func createSourceDir(t *testing.T) (tmp, src string, fcount int, err error) {
 			t.Skipf("unable to write to %s: %s", tmpfile.Name(), err)
 		}
 	}
-	return tmp, src, fcount, nil
+	return tmp, src, fcount
 }
 
 func TestCopyAllDirDstPresent(t *testing.T) {
-	tmp, src, fcount, err := createSourceDir(t)
+	tmp, src, fcount := createSourceDir(t)
 	defer os.RemoveAll(tmp)
 
 	dst := filepath.Join(tmp, "/dst")
-	err = os.MkdirAll(dst, 0750)
+	err := os.MkdirAll(dst, 0750)
 	if err != nil {
 		t.Skipf("unable to create dst dir: %s", err)
 	}
@@ -58,14 +58,14 @@ func TestCopyAllDirDstPresent(t *testing.T) {
 }
 
 func TestCopyAllDirDstAbsent(t *testing.T) {
-	tmp, src, fcount, err := createSourceDir(t)
+	tmp, src, fcount := createSourceDir(t)
 	defer os.RemoveAll(tmp)
 
 	// no destination directory
 	dst := filepath.Join(tmp, "/dst")
 
 	var cnt uint
-	err = copyAll(src, dst, &cnt)
+	err := copyAll(src, dst, &cnt)
 	if err != nil {
 		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
 	}
@@ -78,9 +78,9 @@ func TestCopyAllDirDstAbsent(t *testing.T) {
 }
 
 // populates a test workspace (tmp) with a src file
-func createSourceFile(t *testing.T) (tmp, src string, fcount int, err error) {
+func createSourceFile(t *testing.T) (tmp, src string, fcount int) {
 	// create a workspace
-	tmp, err = ioutil.TempDir("", "robotest-test")
+	tmp, err := ioutil.TempDir("", "robotest-test")
 	if err != nil {
 		t.Skipf("unable to create tempdir: %s", err)
 	}
@@ -92,16 +92,16 @@ func createSourceFile(t *testing.T) (tmp, src string, fcount int, err error) {
 		t.Skipf("unable to write to %s: %s", src, err)
 	}
 
-	return tmp, src, fcount, nil
+	return tmp, src, fcount
 }
 
 func TestCopyAllFileDstPresent(t *testing.T) {
-	tmp, src, fcount, err := createSourceFile(t)
+	tmp, src, fcount := createSourceFile(t)
 	defer os.RemoveAll(tmp)
 
 	// create destination directory
 	dst := filepath.Join(tmp, "/dst")
-	err = os.MkdirAll(dst, 0750)
+	err := os.MkdirAll(dst, 0750)
 	if err != nil {
 		t.Skipf("unable to create dst dir: %s", err)
 	}
@@ -117,14 +117,14 @@ func TestCopyAllFileDstPresent(t *testing.T) {
 }
 
 func TestCopyAllFileDstAbsent(t *testing.T) {
-	tmp, src, fcount, err := createSourceFile(t)
+	tmp, src, fcount := createSourceFile(t)
 	defer os.RemoveAll(tmp)
 
 	// no destination directory
 	dst := filepath.Join(tmp, "/dst")
 
 	var cnt uint
-	err = copyAll(src, dst, &cnt)
+	err := copyAll(src, dst, &cnt)
 	if err != nil {
 		t.Errorf("copy %q -> %q failed: %s", src, dst, err)
 	}


### PR DESCRIPTION
As I've been messing with robotest, I found a bug with copyall.  It contains logic for the src being a regular file, but will fail to create a directory -- unlike when the source was a directory.

This level of testing is probably overblown in the long run, but because I'm still learning go, I'm using these early patches as a playground to work on my skills.  Any and all feedback is appreciated... I don't know much/anything about go standards and conventions yet.

Testing Done:

See the tests added.  Here's the run before & after:
```
walt@work:~/git/robotest$ git checkout HEAD^
# snip 'detached HEAD' message
HEAD is now at 305e10d Add tests for the copyAll function.
walt@work:~/git/robotest$ go test ./lib/system       
--- FAIL: TestCopyAllFileDstAbsent (0.00s)
    file_test.go:133: copy "/tmp/robotest-test138762263/src" -> "/tmp/robotest-test138762263/dst" failed: open /tmp/robotest-test138762263/dst/727014538: no such file or directory
    file_test.go:139: expected /tmp/robotest-test138762263/dst to be created
FAIL
FAIL    github.com/gravitational/robotest/lib/system    0.005s
FAIL
walt@work:~/git/robotest$ git checkout copyall-fix                                                                                                                                        [1]
Previous HEAD position was 305e10d Add tests for the copyAll function.
Switched to branch 'copyall-fix'
walt@work:~/git/robotest$ go test ./lib/system    
ok      github.com/gravitational/robotest/lib/system    (cached)
```