### PR TITLE
Make terraform plugin dir configurable.

### DIFF
--- a/infra/gravity/config.go
+++ b/infra/gravity/config.go
@@ -81,7 +81,7 @@ type ProvisionerConfig struct {
 
 	// ScriptPath is the path to the terraform script or directory for provisioning
 	ScriptPath string `yaml:"script_path" validate:"required"`
-	// TerraformPluginDir
+	// TerraformPluginDir is the path to the terraform plugin directory
 	TerraformPluginDir string `yaml:"tf_plugin_dir"`
 	// InstallerURL specifies the location of the installer tarball.
 	// Can either be a local path or S3 URL

--- a/infra/gravity/config.go
+++ b/infra/gravity/config.go
@@ -81,6 +81,8 @@ type ProvisionerConfig struct {
 
 	// ScriptPath is the path to the terraform script or directory for provisioning
 	ScriptPath string `yaml:"script_path" validate:"required"`
+	// TerraformPluginDir
+	TerraformPluginDir string `yaml:"tf_plugin_dir"`
 	// InstallerURL specifies the location of the installer tarball.
 	// Can either be a local path or S3 URL
 	InstallerURL string `yaml:"installer_url" validate:"required"`

--- a/infra/gravity/terraform.go
+++ b/infra/gravity/terraform.go
@@ -197,11 +197,18 @@ func makeDynamicParams(baseConfig ProvisionerConfig) (*cloudDynamicParams, error
 
 	param.homeDir = filepath.Join("/home", param.user)
 
+	// this seems like an awkward way to set a default value, there must be a better pattern
+	// -- 2020-02 wdella
+	if baseConfig.TerraformPluginDir == "" {
+		baseConfig.TerraformPluginDir = "/etc/terraform/plugins"
+	}
+
 	param.terraform = terraform.Config{
 		CloudProvider: baseConfig.CloudProvider,
 		ScriptPath:    baseConfig.ScriptPath,
 		NumNodes:      int(baseConfig.NodeCount),
 		OS:            baseConfig.os.String(),
+		PluginDir:     baseConfig.TerraformPluginDir,
 	}
 
 	if baseConfig.AWS != nil {

--- a/infra/gravity/terraform.go
+++ b/infra/gravity/terraform.go
@@ -197,8 +197,6 @@ func makeDynamicParams(baseConfig ProvisionerConfig) (*cloudDynamicParams, error
 
 	param.homeDir = filepath.Join("/home", param.user)
 
-	// this seems like an awkward way to set a default value, there must be a better pattern
-	// -- 2020-02 wdella
 	if baseConfig.TerraformPluginDir == "" {
 		baseConfig.TerraformPluginDir = "/etc/terraform/plugins"
 	}

--- a/infra/terraform/config.go
+++ b/infra/terraform/config.go
@@ -96,4 +96,6 @@ type Config struct {
 	VarFilePath string `json:"var_file_path" yaml:"var_file_path"`
 	// OnpremProvider specifies usage of onprem provider for installation
 	OnpremProvider bool `json:"onprem_provider" yaml:"onprem_provider"`
+	// PluginDir is the directory terraform plugins reside in
+	PluginDir string `json:"plugin_dir,omitempty" yaml:"plugin_dir,omitempty"`
 }

--- a/infra/terraform/terraform.go
+++ b/infra/terraform/terraform.go
@@ -38,9 +38,11 @@ func New(stateDir string, config Config) (*terraform, error) {
 			constants.FieldProvisioner: "terraform",
 			constants.FieldCluster:     config.ClusterName,
 			"state-dir":                stateDir,
+			"plugin-dir":               config.PluginDir,
 		}),
-		Config:   config,
-		stateDir: stateDir,
+		Config:    config,
+		stateDir:  stateDir,
+		pluginDir: config.PluginDir,
 		// pool will be reset in Create
 		pool: infra.NewNodePool(nil, nil),
 
@@ -297,7 +299,7 @@ func (r *terraform) State() infra.ProvisionerState {
 func (r *terraform) boot(ctx context.Context) (rc io.ReadCloser, err error) {
 	out, err := r.command(ctx, []string{
 		"init", "-input=false", "-get-plugins=false",
-		fmt.Sprintf("-plugin-dir=%v", constants.TerraformPluginDir),
+		fmt.Sprintf("-plugin-dir=%v", r.PluginDir),
 		r.stateDir},
 	)
 	if err != nil {
@@ -432,6 +434,7 @@ type terraform struct {
 	stateDir       string
 	installerIP    string
 	loadbalancerIP string
+	pluginDir      string
 }
 
 type outputs struct {

--- a/infra/terraform/terraform.go
+++ b/infra/terraform/terraform.go
@@ -40,9 +40,8 @@ func New(stateDir string, config Config) (*terraform, error) {
 			"state-dir":                stateDir,
 			"plugin-dir":               config.PluginDir,
 		}),
-		Config:    config,
-		stateDir:  stateDir,
-		pluginDir: config.PluginDir,
+		Config:   config,
+		stateDir: stateDir,
 		// pool will be reset in Create
 		pool: infra.NewNodePool(nil, nil),
 

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -42,9 +42,6 @@ const (
 
 	// ManifestStorageDriver is empty string identifying that install should use driver defined by the manifest
 	ManifestStorageDriver = ""
-
-	// TerraformPluginDir specifies the location of terraform plugins
-	TerraformPluginDir = "/etc/terraform/plugins"
 )
 
 const (


### PR DESCRIPTION
Before this patch, robotest read terraform plugins from
/etc/terraform/plugins. /etc is only writeable by root so this became a
limiting factor preventing robotest dev environment setup without without
root privileges.

I recognize running robotest outside of its contianer is a somewhat
oblique use case, but it is something that both @bernardjkim and I
have found useful while getting started with the tool. In particular,
I find running outside containers useful for running robotest with
delve.

Testing done:

With the new setting:
```
walt@work:~/git/robotest$ ./debug.sh                 
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=redacted -test.parallel=1 -repeat=1 -fail-fast=true '-provision=
installer_url: telekube-6.3.6-linux-x86_64.tar
gravity_url: /home/walt/go/bin/gravity
script_path: /home/walt/git/robotest/assets/terraform/gce
tf_plugin_dir: /home/walt/.terraform.d/plugins/linux_amd64
state_dir: /home/walt/git/robotest/wd_suite/state
cloud: gce
aws:
  access_key: redacted
  secret_key: redacted
  ssh_user: ubuntu
  key_path: /home/walt/.ssh/robotest.pub
  key_pair: irrelevant
  region: us-east-1
  vpc: Create New
  docker_device: /dev/xvdb

gce:
  credentials: /home/walt/.gcp-4f6eeb4b0c25.json
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /home/walt/.ssh/robotest
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub
  var_file_path: /home/walt/git/robotest/wd_suite/gcp_vars.json
' -resourcegroup-file=/home/walt/git/robotest/wd_suite/state/alloc.txt -always-collect-logs=true -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug 'upgrade3lts={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","storage_driver":"overlay2","from":"/home/walt/git/robotest/gravity-6.1.9.tar"}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060              
INFO RUNNING                                       logs="redacted" name=walt-upgrade3lts-1 param="{"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"18"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/home/walt/git/robotest/gravity-6.1.9.tar"}" where=[/retry.go:36]

... snip debug ...

INFO[0000] Command started.                              cluster= cmd=/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 /home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf pid=13705 plugin-dir="/home/walt/.terraform.d/plugins/linux_amd64" provisioner=terraform state-dir="/home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf"
INFO[0001] Command finished.                             cluster= cmd=/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 /home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf error=<nil> output="
Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
" pid=15381 plugin-dir="/home/walt/.terraform.d/plugins/linux_amd64" provisioner=terraform state-dir="/home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf"
```

Without the new setting:
```
walt@work:~/git/robotest$ ./debug.sh 
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=redacted -test.parallel=1 -repeat=1 -fail-fast=true '-provision=
installer_url: telekube-6.3.6-linux-x86_64.tar
gravity_url: /home/walt/go/bin/gravity
script_path: /home/walt/git/robotest/assets/terraform/gce
state_dir: /home/walt/git/robotest/wd_suite/state
cloud: gce
aws:
  access_key: redacted
  secret_key: redacted
  ssh_user: ubuntu
  key_path: /home/walt/.ssh/robotest.pub
  key_pair: irrelevant
  region: us-east-1
  vpc: Create New
  docker_device: /dev/xvdb

gce:
  credentials: /home/walt/.gcp-4f6eeb4b0c25.json
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /home/walt/.ssh/robotest
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub
  var_file_path: /home/walt/git/robotest/wd_suite/gcp_vars.json
' -resourcegroup-file=/home/walt/git/robotest/wd_suite/state/alloc.txt -always-collect-logs=true -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug 'upgrade3lts={"flavor":"three","nodes":3,"role":"node","os":"ubuntu:18","storage_driver":"overlay2","from":"/home/walt/git/robotest/gravity-6.1.9.tar"}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060              
INFO RUNNING                                       logs="redacted" name=walt-upgrade3lts-1 param="{"role":"node","cluster":"","flavor":"three","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"18"},"storage_driver":"overlay2","nodes":3,"script":null,"from":"/home/walt/git/robotest/gravity-6.1.9.tar"}" where=[/retry.go:36]

... snip debug ...

INFO[0001] Command started.                              cluster= cmd=/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/etc/terraform/plugins /home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf pid=18139 plugin-dir="/etc/terraform/plugins" provisioner=terraform state-dir="/home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf"
INFO[0001] Command finished.                             cluster= cmd=/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/etc/terraform/plugins /home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf error="exit status 1" output="
Initializing the backend...

Initializing provider plugins...

Missing required providers.

The following provider constraints are not met by the currently-installed
provider plugins:

* google (>= 1.19)
* random (>= 2.0)
* template (>= 1.0)

Terraform can automatically download and install plugins to meet the given
constraints, but this step was skipped due to the use of -get-plugins=false
and/or -plugin-dir on the command line.

If automatic installation is not possible or desirable in your environment,
you may manually install plugins by downloading a suitable distribution package
and placing the plugin's executable file in one of the directories given in
by -plugin-dir on the command line, or in the following directory if custom
plugin directories are not set:
    terraform.d/plugins/linux_amd64


Error: missing provider "google"



Error: missing provider "random"



Error: missing provider "template"


" pid=18139 plugin-dir="/etc/terraform/plugins" provisioner=terraform state-dir="/home/walt/git/robotest/wd_suite/state/walt/upgrade3lts-1/ubuntu18/overlay2/3n/tf"
```