### PR TITLE
A couple of tweaks

### DIFF
--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -54,7 +54,7 @@ function setup-user {
     retry restorecon -vR /home/${os_user}
   fi
 
-  chown -R $service_uid:$service_gid /var/lib/gravity $etcd_dir /home/${os_user}
+  chown -R $service_uid:$service_gid /home/${os_user}
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
 

--- a/assets/terraform/gce/bootstrap/suse.sh
+++ b/assets/terraform/gce/bootstrap/suse.sh
@@ -41,7 +41,7 @@ function setup-user {
     chmod 0600 /home/${os_user}/.ssh/authorized_keys
   fi
 
-  chown -R $service_uid:$service_gid /var/lib/gravity $etcd_dir /home/${os_user}
+  chown -R $service_uid:$service_gid /home/${os_user}
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
 

--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -49,7 +49,7 @@ function setup-user {
     chsh -s /bin/bash ${os_user}
   fi
 
-  chown -R $service_uid:$service_gid /var/lib/gravity $etcd_dir /home/${os_user}
+  chown -R $service_uid:$service_gid /home/${os_user}
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
 

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -190,10 +190,6 @@ func (c *TestContext) Upgrade(nodes []Gravity, installerURL, gravityURL, subdir 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = c.Status(nodes)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	return c.upgrade(master, len(nodes))
 }
 
@@ -205,6 +201,11 @@ func (c *TestContext) uploadInstaller(master Gravity, nodes []Gravity, installer
 	defer cancel()
 
 	err := master.SetInstaller(ctx, installerURL, subdir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = c.Status(nodes)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
 * Moves status query before the call to `uploadUpgrade` to counter recent test failures. `uploadUpgrade` only verifies the status in the cluster record and might fail due to an intermittent issue. This is not an ideal solution but might help avoid test failures.
 * Removes state/etcd directories from the chowned list - these will be configured by the installer. The reason this is not done in the bootstrap script is that the script also runs on reboot and will break
the access to directories that aren't expected to be owned by the service user (which is especially critical with SELinux enabled).