### PR TITLE
Rename upgrade3lts to upgrade.

### DIFF
--- a/suite/README.md
+++ b/suite/README.md
@@ -101,7 +101,7 @@ Inherits parameters from `install`, plus:
 
 ### Install cluster, then upgrade
 
-`upgrade3lts` - current upgrade procedure for 3.x LTS branch. Inherits parameters from `install`. 
+`upgrade` inherits parameters from `install`.
 
 * `upgrade_from` initial installer to use
 

--- a/suite/sanity/sanity.go
+++ b/suite/sanity/sanity.go
@@ -23,7 +23,7 @@ func Suite() *config.Config {
 	cfg.Add("install", install, defaultInstallParam)
 	cfg.Add("recover", lossAndRecovery, lossAndRecoveryParam{installParam: defaultInstallParam})
 	cfg.Add("recoverV", lossAndRecoveryVariety, defaultInstallParam)
-	cfg.Add("upgrade3lts", upgrade, upgradeParam{installParam: defaultInstallParam})
+	cfg.Add("upgrade", upgrade, upgradeParam{installParam: defaultInstallParam})
 	cfg.Add("autoscale", autoscale, defaultInstallParam)
 
 	return cfg


### PR DESCRIPTION
Gravity 3 (where this name originated) is no longer supported, and this
test works with all supported gravity versions (5.x, 6.x, 7.x).  The
'3lts' affix is a vestigial quirk at this point.

This will require gravity CI scripts to update their syntax when they
migrate to a robotest version including this change.

The `upgrade3lts` name originated here, where it was changed from `upgrade`:

https://github.com/gravitational/robotest/commit/9bbf248dd124df62163812be1bd687f32e49b42b#diff-159fff6b77474dac6556f177cd277455R92

### Testing Done:
None yet.  But I'll rebase some of my other work on top of this and give it a shot.