### PR TITLE
Turn off GCP preemptible instances by default.

### DIFF
--- a/assets/terraform/gce/config.tf
+++ b/assets/terraform/gce/config.tf
@@ -67,7 +67,7 @@ variable "disk_type" {
 variable "preemptible" {
   description = "Whether to use preemptible VMs. See https://cloud.google.com/preemptible-vms"
   type        = string
-  default     = "true"
+  default     = "false"
 }
 
 provider "google" {

--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -21,7 +21,7 @@ FAIL_FAST=${FAIL_FAST:-false}
 ALWAYS_COLLECT_LOGS=${ALWAYS_COLLECT_LOGS:-true}
 GCE_VM=${GCE_VM:-'custom-8-8192'}
 GCE_REGION=${GCE_REGION:-'northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1'}
-GCE_PREEMPTIBLE=${GCE_PREEMPTIBLE:-'true'}
+GCE_PREEMPTIBLE=${GCE_PREEMPTIBLE:-'false'}
 DOCKER_DEVICE=${DOCKER_DEVICE:-'/dev/sdc'}
 
 # choose something relatively unique to avoid intersection with other people runs


### PR DESCRIPTION
As discussed in:

  https://github.com/gravitational/gravity/commit/6d0e6b2141af41a0c3b86ce093120d4d9af42feb
  https://github.com/gravitational/gravity/commit/7af1def4f624bfc2d7e7f5580fea399daa2921e6

Using GCE preemptible instances has not shown sufficient benefit.  As
such, Robotest will now default to using regular instances, and count on
consumers to enable preemption if they want to use it.

### Testing Done
None yet.  I will post results once I've used this in some of my work on #189.