### PR TITLE
Remove unused InstallParams.

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -88,16 +88,8 @@ type InstallParam struct {
 	Cluster string `json:"cluster"`
 	// Flavor is Application flavor. See Application Manifest for details.
 	Flavor string `json:"flavor" validate:"required"`
-	// K8SConfigURL is (Optional) File with Kubernetes resources to create in the cluster during installation.
-	K8SConfigURL string `json:"k8s_config_url,omitempty"`
-	// PodNetworkCidr is (Optional) CIDR range Kubernetes will be allocating node subnets and pod IPs from. Must be a minimum of /16 so Kubernetes is able to allocate /24 to each node. Defaults to 10.244.0.0/16.
-	PodNetworkCIDR string `json:"pod_network_cidr,omitempty"`
-	// ServiceCidr (Optional) CIDR range Kubernetes will be allocating service IPs from. Defaults to 10.100.0.0/16.
-	ServiceCIDR string `json:"service_cidr,omitempty"`
 	// EnableRemoteSupport (Optional) whether to register this installation with remote ops-center
 	EnableRemoteSupport bool `json:"remote_support"`
-	// LicenseURL (Optional) is license file, could be local or s3 or http(s) url
-	LicenseURL string `json:"license,omitempty"`
 	// CloudProvider defines tighter integration with cloud vendor, i.e. use AWS networking on Amazon
 	CloudProvider string `json:"cloud_provider,omitempty"`
 	// GCENodeTag specifies the node tag on GCE.


### PR DESCRIPTION
The k8s_config_url, pod_network_cidr, service_cidr, and license fields
were defined but undocumented and never used anywhere in
Robotest's code.  Setting them would have no effect.

I've chosen to remove these flags (instead of plumb them through)
because the testing necessary for plumbing them through is not presently
at the top of my priority list. Better to remove dead/unsupported code than
keep it around in hopes it may someday be useful.

### Testing Done
The following run was done on a branch with these changes: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-03-25T21:11:57.234000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22ed3623f1-89c4-47d5-819c-a30e003afadf%22%0Alabels.__suite__%3D%229c9da97a-eef8-4c38-9c94-215b667ff1bb%22%0AjsonPayload.param:%22service_uid%22%0AOR%20jsonPayload.cmd:%22--service-uid%22&dateRangeStart=2020-03-25T20:15:34.543Z&interval=PT1H&scrollTimestamp=2020-03-25T21:08:27.258217922Z&dateRangeEnd=2020-03-25T21:15:34.543Z)