### PR TITLE
Add service_uid and service_gid install params.

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -113,6 +113,10 @@ type InstallParam struct {
 	InstallerURL string `json:"installer_url,omitempty"`
 	// OpsAdvertiseAddr is optional Ops Center advertise address to pass to the install command
 	OpsAdvertiseAddr string `json:"ops_advertise_addr,omitempty"`
+	// ServiceUID is an optional parameter for install's --service-uid flag: https://gravitational.com/gravity/docs/ver/7.x/pack/#service-user
+	ServiceUID *uint `json:"service_uid,omitempty"`
+	// ServiceGID is an optional parameter for install's --service-gid flag
+	ServiceGID *uint `json:"service_gid,omitempty"`
 }
 
 // JoinCmd represents various parameters for Join
@@ -278,7 +282,9 @@ var installCmdTemplate = template.Must(
 		--cloud-provider=generic --state-dir={{.StateDir}} \
 		--httpprofile=localhost:6061 \
 		{{if .Cluster}}--cluster={{.Cluster}}{{end}} \
-		{{if .OpsAdvertiseAddr}}--ops-advertise-addr={{.OpsAdvertiseAddr}}{{end}}
+		{{if .OpsAdvertiseAddr}}--ops-advertise-addr={{.OpsAdvertiseAddr}}{{end}}\
+		{{if .ServiceUID}}--service-uid={{.ServiceUID}}{{end}}\
+		{{if .ServiceGID}}--service-gid={{.ServiceGID}}{{end}}\
 `))
 
 // Status queries cluster status

--- a/suite/README.md
+++ b/suite/README.md
@@ -87,6 +87,8 @@ Every test is passed as argument to launch script as `testname={json}`. Mind the
 * `flavor` (string) flavor corresponding to number of nodes.
 * `remote_support` (bool, default=false) enable remote support via `gravity complete` after install using OPS center and token burned into installer.
 * `uninstall` (bool, default=false) uninstall at the end
+* `service_uid` (uint, default=gravity default) the uid that planet will run under, see https://gravitational.com/gravity/docs/ver/7.x/pack/#service-user
+* `service_gid` (uint, default=gravity default) the gid that planet will run under
 
 `provision` takes same args but will not run any installer, just provision VMs. 
 


### PR DESCRIPTION
We have customers in the field that use the `--service-uid` and
`--service-gid` flags on their gravity clusters and are
reporting issues after upgrades related to these flags:

    https://github.com/gravitational/gravity/issues/1279

Fixes #189.

### Testing Done
[One node install test logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-03-26T00:57:55.032000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2225b8c851-a881-428f-9325-3e42399942bd%22%0Alabels.__suite__%3D%22350907b0-48ce-4810-98a0-b650f358d5ff%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-03-25T23:57:55.472Z&dateRangeEnd=2020-03-26T00:57:55.472Z&interval=PT1H&scrollTimestamp=2020-03-26T00:39:15.409500178Z)
[5.5.28 -> 5.5.38 upgrade test logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-03-26T00:57:55.032000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2225b8c851-a881-428f-9325-3e42399942bd%22%0Alabels.__suite__%3D%22350907b0-48ce-4810-98a0-b650f358d5ff%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-03-25T23:57:55.472Z&dateRangeEnd=2020-03-26T00:57:55.472Z&interval=PT1H&scrollTimestamp=2020-03-26T00:39:15.409500178Z)

Also, a quick check of json deserialization with uint pointers:
```go
package main

import (
	"html/template"
	"os"
	"encoding/json"
)

type Data struct {
	Value *uint `json:"value,omitempty"`
}

func main() {
	var d1, d2 Data
	json.Unmarshal([]byte(`{"value":5}`), &d1)
	json.Unmarshal([]byte(`{}`), &d2)
	
	t := template.Must(template.New("whatever").Parse("{{if .Value}}Value: {{.Value}}{{else}}Value is nil{{end}}\n"))
	err := t.Execute(os.Stdout, d1)
	if err != nil {
		panic(err)
	}
	err = t.Execute(os.Stdout, d2)
	if err != nil {
		panic(err)
	}
}
```
```
Value: 5
Value is nil
```