### PR TITLE
Use sudo when querying post-operation status.

### DIFF
--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -568,11 +568,10 @@ const (
 // runOp launches specific command and waits for operation to complete, ignoring transient errors
 func (g *gravity) runOp(ctx context.Context, command string, env map[string]string) error {
 	var code string
-	executablePath := filepath.Join(g.installDir, "gravity")
+	sudoGravity := fmt.Sprintf(`cd %v && sudo -E ./gravity`, g.installDir)
 	logPath := filepath.Join(g.installDir, defaults.AgentLogPath)
 	err := sshutils.RunAndParse(ctx, g.Client(), g.Logger(),
-		fmt.Sprintf(`sudo -E %v %v --insecure --quiet --system-log-file=%v`,
-			executablePath, command, logPath),
+		fmt.Sprintf(`%v %v --insecure --quiet --system-log-file=%v`, sudoGravity, command, logPath),
 		env, sshutils.ParseAsString(&code))
 	if err != nil {
 		return trace.Wrap(err)
@@ -589,9 +588,8 @@ func (g *gravity) runOp(ctx context.Context, command string, env map[string]stri
 
 	err = retry.Do(ctx, func() error {
 		var response string
-		cmd := fmt.Sprintf(`cd %s && ./gravity status --operation-id=%s -q`, g.installDir, code)
-		err := sshutils.RunAndParse(ctx, g.Client(), g.Logger(),
-			cmd, nil, sshutils.ParseAsString(&response))
+		cmd := fmt.Sprintf(`%v status --quiet --operation-id=%s`, sudoGravity, code)
+		err := sshutils.RunAndParse(ctx, g.Client(), g.Logger(), cmd, nil, sshutils.ParseAsString(&response))
 		if err != nil {
 			return wait.Continue(cmd)
 		}


### PR DESCRIPTION
Older version of gravity try to read `/var/lib/gravity/local/gravity.db`
with the current user.  When these files are owned by someone other than
the current user (i.e. the system_uid/system_gid parameters are set)
`gravity status` will always fail with:

  open /var/lib/gravity/local/gravity.db: permission denied

We avoid these permission problems by using sudo to run gravity (which
is consistent with all other executions of gravity in node_commands.go).

Fixes #194.

### Testing Done
Before this change: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-03-26T23:27:47.848000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-03-26T22:28:13.863Z&interval=PT1H&scrollTimestamp=2020-03-26T23:26:59.342140371Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22eeee4fc2-9030-4496-8431-79c3dcb2d5f9%22%0Alabels.__suite__%3D%22dacbcbe5-acce-40e8-b48a-45588beb350b%22%0Aseverity%3E%3DINFO&dateRangeEnd=2020-03-26T23:28:13.863Z)
After this change: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-03-26T23:27:47.848000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-03-26T22:28:13.863Z&interval=PT1H&scrollTimestamp=2020-03-26T23:26:59.342140371Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22eeee4fc2-9030-4496-8431-79c3dcb2d5f9%22%0Alabels.__suite__%3D%22dacbcbe5-acce-40e8-b48a-45588beb350b%22%0Aseverity%3E%3DINFO&dateRangeEnd=2020-03-26T23:28:13.863Z)