### PR TITLE
Pass `os` and `nodes` via robotest.tfvars.json.

### DIFF
--- a/infra/terraform/terraform_test.go
+++ b/infra/terraform/terraform_test.go
@@ -1,0 +1,98 @@
+package terraform
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/gravitational/robotest/infra/providers/gce"
+)
+
+func TestConvertConfigToTerraformVars(t *testing.T) {
+	gceConfig := gce.Config{
+		Credentials:      "/robotest/gce-creds.json",
+		VMType:           "excellent",
+		SSHUser:          "ubuntu",
+		SSHPublicKeyPath: "/robotest/.ssh/robo.pub",
+		SSHKeyPath:       "/robotest/.ssh/robo",
+		NodeTag:          "unittest",
+	}
+	cfg := Config{
+		CloudProvider: "gce",
+		GCE:           &gceConfig,
+		OS:            "ubuntu:20",
+		ScriptPath:    "/robotest/assets/terraform/gce",
+		NumNodes:      3,
+		InstallerURL:  "s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.0/linux/x86_64/telekube-7.0.0-linux-x86_64.tar",
+		DockerDevice:  "/dev/xvdb",
+		VarFilePath:   "/robotest/custom-vars.json",
+	}
+	cfg.Validate()
+
+	configMap, err := configToTerraformVars(cfg)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := make(map[string]interface{})
+	expected["credentials"] = "/robotest/gce-creds.json"
+	expected["nodes"] = 3
+	expected["vm_type"] = "excellent"
+	expected["os"] = "ubuntu:20"
+	expected["os_user"] = "ubuntu"
+	expected["ssh_pub_key_path"] = "/robotest/.ssh/robo.pub"
+	expected["node_tag"] = "unittest"
+
+	b, err := json.Marshal(configMap)
+	e, err := json.Marshal(expected)
+	if !reflect.DeepEqual(b, e) {
+		t.Errorf("\ngot:\t\t%q\nexpected:\t%q", b, e)
+	}
+}
+
+func TestConvertConfigToTerraformVarsOptionalValues(t *testing.T) {
+	gceConfig := gce.Config{
+		Region:           "us-west1",
+		Zone:             "us-west-1-b",
+		Project:          "unittesting",
+		Credentials:      "/robotest/gce-creds.json",
+		VMType:           "excellent",
+		SSHUser:          "ubuntu",
+		SSHPublicKeyPath: "/robotest/.ssh/robo.pub",
+		SSHKeyPath:       "/robotest/.ssh/robo",
+		NodeTag:          "unittest",
+	}
+	cfg := Config{
+		CloudProvider: "gce",
+		GCE:           &gceConfig,
+		OS:            "ubuntu:20",
+		ScriptPath:    "/robotest/assets/terraform/gce",
+		NumNodes:      3,
+		InstallerURL:  "s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.0/linux/x86_64/telekube-7.0.0-linux-x86_64.tar",
+		DockerDevice:  "/dev/xvdb",
+		VarFilePath:   "/robotest/custom-vars.json",
+	}
+	cfg.Validate()
+
+	configMap, err := configToTerraformVars(cfg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := make(map[string]interface{})
+	expected["region"] = "us-west1"
+	expected["zone"] = "us-west-1-b"
+	expected["project"] = "unittesting"
+	expected["credentials"] = "/robotest/gce-creds.json"
+	expected["nodes"] = 3
+	expected["vm_type"] = "excellent"
+	expected["os"] = "ubuntu:20"
+	expected["os_user"] = "ubuntu"
+	expected["ssh_pub_key_path"] = "/robotest/.ssh/robo.pub"
+	expected["node_tag"] = "unittest"
+
+	b, err := json.Marshal(configMap)
+	e, err := json.Marshal(expected)
+	if !reflect.DeepEqual(b, e) {
+		t.Errorf("\ngot:\t\t%q\nexpected:\t%q", b, e)
+	}
+}


### PR DESCRIPTION
## Description
This is a maintainer Quality of Life change.

These two parameters were previously handled as cli flags. This meant we
had two paths for routing data, and more annoyingly: it wasn't easy to
recreate a robotest `terraform apply` or `terraform destroy` via the
command line because these two values needed to be manually specified in
addition to the other values that came from robotest.tfvars.json.

## Type of change
* Internal change (not necessarily or a new feature)

## Linked tickets and other PRs
N/A.  

## TODOs
<!--Required. Keep only those that apply and check them off as they get completed.-->

- [x] Self-review the change
- [x] Write tests
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Implementation
<!--Optional. Add any relevant implementation details that might help the reviewers.-->

## Testing done
When I have a development run leak resources, and I try to manually clean up, I will navigate to the terraform directory and run `terraform destroy`.  This previously resulted in the following prompt:

```
walt@work:~/git/robotest/logs/0504-1616/walt/install-1/ubuntu18/overlay2/1n/tf$ terraform destroy -var-file robotest.tfvars.json
var.os
  Linux distribution as name:version, i.e. debian:9

  Enter a value: 
```

And after these changes:

```
walt@work:~/git/robotest/logs/0504-2221/walt/install-1/ubuntu18/overlay2/1n/tf$ cat robotest.tfvars.json 
{
  "credentials": "/home/walt/git/robotest/kubeadm-167321-2d663815917d.json",
  "node_tag": "robotest-a56ae835",
  "nodes": 1,
  "os": "ubuntu:18",
  "os_user": "ubuntu",
  "region": "us-west1",
  "ssh_pub_key_path": "/home/walt/.ssh/robotest.pub",
  "vm_type": "custom-8-8192"
 }
walt@work:~/git/robotest/logs/0504-2221/walt/install-1/ubuntu18/overlay2/1n/tf$ terraform destroy -var-file robotest.tfvars.json 
data.template_file.bootstrap: Refreshing state...
data.google_compute_zones.available: Refreshing state...
data.google_compute_subnetwork.robotest: Refreshing state...
data.google_compute_network.robotest: Refreshing state...
// snip
```

No os prompt, correct number of nodes for the run present in the vars file.
