### PR TITLE
Add GCP "robotest" label

### DIFF
--- a/assets/terraform/gce/node.tf
+++ b/assets/terraform/gce/node.tf
@@ -66,12 +66,7 @@ resource "google_compute_instance" "node" {
   min_cpu_platform = "Intel Skylake"
 
   boot_disk {
-    initialize_params {
-      image = var.oss[var.os]
-      size  = 64
-      type  = var.disk_type
-    }
-
+    source = google_compute_disk.boot[count.index].self_link
     auto_delete = true
   }
 
@@ -97,6 +92,19 @@ resource "google_compute_instance" "node" {
 
     # If preempted, the test will be retried with a new configuration
     automatic_restart = var.preemptible ? "false" : "true"
+  }
+}
+
+resource "google_compute_disk" "boot" {
+  count = var.nodes
+  name  = "${var.node_tag}-disk-boot-${count.index}"
+  type  = var.disk_type
+  zone  = local.zone
+  size  = 64
+  image = var.oss[var.os]
+
+  labels = {
+    cluster = var.node_tag
   }
 }
 

--- a/assets/terraform/gce/node.tf
+++ b/assets/terraform/gce/node.tf
@@ -2,6 +2,10 @@
 # Virtual Machine node
 #
 
+# Unfortunately instance groups don't presently accommodate labels which makes
+# them more difficult to track & clean up.  Fortunately, they're not a billed
+# resource, so it doesn't matter as much if robotest leaks them.
+# 2020-05 - walt
 resource "google_compute_instance_group" "robotest" {
   description = "Instance group controlling instances of a single robotest cluster"
   name        = "${var.node_tag}-node-group"
@@ -23,6 +27,7 @@ resource "google_compute_instance" "node" {
   ]
 
   labels = {
+    robotest = ""
     cluster = var.node_tag
   }
 
@@ -104,6 +109,7 @@ resource "google_compute_disk" "boot" {
   image = var.oss[var.os]
 
   labels = {
+    robotest = ""
     cluster = var.node_tag
   }
 }
@@ -116,6 +122,7 @@ resource "google_compute_disk" "etcd" {
   size  = 50
 
   labels = {
+    robotest = ""
     cluster = var.node_tag
   }
 }


### PR DESCRIPTION
## Description
This change adds the "robotest" label to all intances and disks that robotest provisions in GCP.  This is primarily to help track billing of these resources, though it may also be useful for leak tracking & housekeeping purposes.

## Type of change
* New feature (non-breaking change which adds functionality)
* This change has a user-facing impact

## Linked tickets and other PRs
Contributes to https://github.com/gravitational/robotest/issues/164

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Implementation
The  additional resources that we may want to track are:
1) stackdriver logs
2) bigquery entries
3) networks & subnetworks (not currently dynamically provisioned on GCP -- we recycle the same set over & over)

None of these codepaths were substantively similar, so I did not attempt to group them with this change.

## Testing done
I ran a single node install, and then manually re-ran the provision & destroy:
<details>
<summary><code>terraform apply</code>, <code>ssh</code> & <code>terraform destroy</code></summary>
<pre>
walt@work:~/git/robotest/logs/0504-1616/walt/install-1/ubuntu18/overlay2/1n/tf$ terraform apply -var-file robotest.tfvars.json
var.os
  Linux distribution as name:version, i.e. debian:9

  Enter a value: ubuntu:18

data.template_file.bootstrap: Refreshing state...
data.google_compute_network.robotest: Refreshing state...
data.google_compute_zones.available: Refreshing state...
data.google_compute_subnetwork.robotest: Refreshing state...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_compute_disk.boot[0] will be created
  + resource "google_compute_disk" "boot" {
      + creation_timestamp        = (known after apply)
      + id                        = (known after apply)
      + image                     = "ubuntu-os-cloud/ubuntu-1804-bionic-v20200414"
      + label_fingerprint         = (known after apply)
      + labels                    = {
          + "cluster"  = "robotest-a56ae835"
          + "robotest" = ""
        }
      + last_attach_timestamp     = (known after apply)
      + last_detach_timestamp     = (known after apply)
      + name                      = "robotest-a56ae835-disk-boot-0"
      + physical_block_size_bytes = (known after apply)
      + project                   = (known after apply)
      + self_link                 = (known after apply)
      + size                      = 64
      + source_image_id           = (known after apply)
      + source_snapshot_id        = (known after apply)
      + type                      = "pd-ssd"
      + users                     = (known after apply)
      + zone                      = (known after apply)
    }

  # google_compute_disk.etcd[0] will be created
  + resource "google_compute_disk" "etcd" {
      + creation_timestamp        = (known after apply)
      + id                        = (known after apply)
      + label_fingerprint         = (known after apply)
      + labels                    = {
          + "cluster"  = "robotest-a56ae835"
          + "robotest" = ""
        }
      + last_attach_timestamp     = (known after apply)
      + last_detach_timestamp     = (known after apply)
      + name                      = "robotest-a56ae835-disk-etcd-0"
      + physical_block_size_bytes = (known after apply)
      + project                   = (known after apply)
      + self_link                 = (known after apply)
      + size                      = 50
      + source_image_id           = (known after apply)
      + source_snapshot_id        = (known after apply)
      + type                      = "pd-ssd"
      + users                     = (known after apply)
      + zone                      = (known after apply)
    }

  # google_compute_instance.node[0] will be created
  + resource "google_compute_instance" "node" {
      + can_ip_forward          = false
      + cpu_platform            = (known after apply)
      + deletion_protection     = false
      + description             = "Instance is a single robotest cluster node"
      + guest_accelerator       = (known after apply)
      + id                      = (known after apply)
      + instance_id             = (known after apply)
      + label_fingerprint       = (known after apply)
      + labels                  = {
          + "cluster"  = "robotest-a56ae835"
          + "robotest" = ""
        }
      + machine_type            = "custom-8-8192"
      + metadata                = {
          + "ssh-keys" = "..."
        }
      + metadata_fingerprint    = (known after apply)
      + metadata_startup_script = "#!/bin/bash\n#\n# VM bootstrap script for Debian/Ubuntu\n#\nset -exuo pipefail\n\netcd_device_name=sdb\netcd_dir=/var/lib/gravity/planet/etcd\nDIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" >/dev/null && pwd)\"\n\nfunction secure-ssh {\n  local sshd_config=/etc/ssh/sshd_config\n  cp $sshd_config $sshd_config.old\n  (grep -qE '(\\#?)\\WPasswordAuthentication' $sshd_config && \\\n    sed -re 's/^(\\#?)\\W*(PasswordAuthentication)([[:space:]]+)yes/\\2\\3no/' -i $sshd_config) || \\\n    echo 'PasswordAuthentication no' >> $sshd_config\n  (grep -qE '(\\#?)\\WChallengeResponseAuthentication' $sshd_config && \\\n    sed -re 's/^(\\#?)\\W*(ChallengeResponseAuthentication)([[:space:]]+)yes/\\2\\3no/' -i $sshd_config) || \\\n    echo 'ChallengeResponseAuthentication no' >> $sshd_config\n  systemctl reload ssh\n}\n\nfunction remove-sshguard {\n  if systemctl is-active --quiet sshguard; then\n    apt-get -y remove --auto-remove sshguard\n    apt-get -y purge --auto-remove sshguard\n  fi\n}\n\nfunction setup-user {\n  local service_uid=$(id ubuntu -u 2>/dev/null || true)\n  local service_gid=$(id ubuntu -g 2>/dev/null || true)\n\n  if [ -z \"$service_gid\" ]; then\n    service_gid=1000\n    (groupadd --system --non-unique --gid $service_gid ubuntu 2>/dev/null; err=$?; if (( $err != 9 )); then exit $err; fi) || true\n  fi\n\n  if [ -z \"$service_uid\" ]; then\n    service_uid=1000\n    (useradd --system --non-unique --gid $service_gid --uid $service_uid ubuntu 2>/dev/null; err=$?; if (( $err != 9 )); then exit $err; fi) || true\n  fi\n\n  if [ ! -d \"/home/ubuntu/.ssh\" ]; then\n    mkdir -p /home/ubuntu/.ssh\n    echo \"..." | tee /home/ubuntu/.ssh/authorized_keys\n    chmod 0700 /home/ubuntu/.ssh\n    chmod 0600 /home/ubuntu/.ssh/authorized_keys\n    chsh -s /bin/bash ubuntu\n  fi\n\n  chown -R $service_uid:$service_gid /home/ubuntu\n  sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers\n}\n\ntouch /var/lib/bootstrap_started\n\nmkdir -p $etcd_dir /var/lib/data\n\nremove-sshguard\nsecure-ssh\nsetup-user\n\n# Bump number of retries for download failures\necho \"APT::Acquire::Retries \\\"10\\\";\" > /etc/apt/apt.conf.d/80-retries\n\napt-get update\napt-get install -y chrony lvm2 curl wget thin-provisioning-tools python\n\ncurl https://bootstrap.pypa.io/get-pip.py | python -\npip install --upgrade awscli\n\nif ! grep -qs \"$etcd_dir\" /proc/mounts; then\n  mkfs.ext4 -F /dev/$etcd_device_name\n  sed -i.bak \"/$etcd_device_name/d\" /etc/fstab\n  echo -e \"/dev/$etcd_device_name\\t$etcd_dir\\text4\\tdefaults\\t0\\t2\" >> /etc/fstab\n  mount $etcd_dir\nfi\n\n## Setup modules / sysctls\n# Load required kernel modules\nmodules=\"br_netfilter overlay ebtable_filter ip_tables iptable_filter iptable_nat\"\nfor module in $modules; do\n  modprobe $module || true\ndone\n# Store the modules into a file so that the modules will be auto-reloaded\n# on reboot\necho '' > /etc/modules-load.d/telekube.conf\nfor module in $modules; do\n  echo $module >> /etc/modules-load.d/telekube.conf\ndone\n\n# Make changes permanent\ncat > /etc/sysctl.d/50-telekube.conf <<EOF\nnet.ipv4.ip_forward=1\nnet.bridge.bridge-nf-call-iptables=1\nnet.ipv4.tcp_keepalive_time=60\nnet.ipv4.tcp_keepalive_intvl=60\nnet.ipv4.tcp_keepalive_probes=5\nEOF\nsysctl -p /etc/sysctl.d/50-telekube.conf\n\n# Mark bootstrap step complete for robotest\ntouch /var/lib/bootstrap_complete\n"
      + min_cpu_platform        = "Intel Skylake"
      + name                    = "robotest-a56ae835-node-0"
      + project                 = (known after apply)
      + self_link               = (known after apply)
      + tags                    = [
          + "robotest",
          + "robotest-a56ae835-node-0",
        ]
      + tags_fingerprint        = (known after apply)
      + zone                    = (known after apply)

      + attached_disk {
          + device_name                = (known after apply)
          + disk_encryption_key_sha256 = (known after apply)
          + kms_key_self_link          = (known after apply)
          + mode                       = "READ_WRITE"
          + source                     = (known after apply)
        }

      + boot_disk {
          + auto_delete                = true
          + device_name                = (known after apply)
          + disk_encryption_key_sha256 = (known after apply)
          + kms_key_self_link          = (known after apply)
          + mode                       = "READ_WRITE"
          + source                     = (known after apply)

          + initialize_params {
              + image  = (known after apply)
              + labels = (known after apply)
              + size   = (known after apply)
              + type   = (known after apply)
            }
        }

      + network_interface {
          + name               = (known after apply)
          + network            = (known after apply)
          + network_ip         = (known after apply)
          + subnetwork         = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/regions/us-west1/subnetworks/robotest"
          + subnetwork_project = (known after apply)

          + access_config {
              + nat_ip       = (known after apply)
              + network_tier = (known after apply)
            }
        }

      + scheduling {
          + automatic_restart   = true
          + on_host_maintenance = (known after apply)
          + preemptible         = false
        }

      + service_account {
          + email  = (known after apply)
          + scopes = [
              + "https://www.googleapis.com/auth/compute",
              + "https://www.googleapis.com/auth/devstorage.read_only",
              + "https://www.googleapis.com/auth/servicecontrol",
            ]
        }
    }

  # google_compute_instance_group.robotest will be created
  + resource "google_compute_instance_group" "robotest" {
      + description = "Instance group controlling instances of a single robotest cluster"
      + id          = (known after apply)
      + instances   = (known after apply)
      + name        = "robotest-a56ae835-node-group"
      + network     = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/global/networks/robotest"
      + project     = (known after apply)
      + self_link   = (known after apply)
      + size        = (known after apply)
      + zone        = (known after apply)
    }

  # random_shuffle.zones will be created
  + resource "random_shuffle" "zones" {
      + id           = (known after apply)
      + input        = [
          + "us-west1-a",
          + "us-west1-b",
          + "us-west1-c",
        ]
      + result       = (known after apply)
      + result_count = 1
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

random_shuffle.zones: Creating...
random_shuffle.zones: Creation complete after 0s [id=-]
google_compute_disk.boot[0]: Creating...
google_compute_disk.etcd[0]: Creating...
google_compute_disk.boot[0]: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0]
google_compute_disk.etcd[0]: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0]
google_compute_instance.node[0]: Creating...
google_compute_instance.node[0]: Still creating... [10s elapsed]
google_compute_instance.node[0]: Creation complete after 17s [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0]
google_compute_instance_group.robotest: Creating...
google_compute_instance_group.robotest: Creation complete after 7s [id=projects/kubeadm-167321/zones/us-west1-b/instanceGroups/robotest-a56ae835-node-group]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

private_ips = [
  "10.138.0.14",
]
public_ips = [
  "34.82.197.133",
]
walt@work:~/git/robotest/logs/0504-1616/walt/install-1/ubuntu18/overlay2/1n/tf$ ssh ubuntu@34.82.197.133
The authenticity of host '34.82.197.133 (34.82.197.133)' can't be established.
ECDSA key fingerprint is <...>.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '34.82.197.133' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 18.04.4 LTS (GNU/Linux 5.0.0-1034-gcp x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Mon May  4 23:38:23 UTC 2020

  System load:  0.3               Processes:           170
  Usage of /:   2.0% of 61.86GB   Users logged in:     0
  Memory usage: 4%                IP address for ens4: 10.138.0.14
  Swap usage:   0%

0 packages can be updated.
0 updates are security updates.



The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@robotest-a56ae835-node-0:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            3.9G     0  3.9G   0% /dev
tmpfs           798M  996K  797M   1% /run
/dev/sda1        62G  1.3G   61G   2% /
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           3.9G     0  3.9G   0% /sys/fs/cgroup
/dev/sda15      105M  3.6M  101M   4% /boot/efi
tmpfs           798M     0  798M   0% /run/user/1000
/dev/loop0       94M   94M     0 100% /snap/core/8935
/dev/loop1       55M   55M     0 100% /snap/core18/1705
/dev/loop2       98M   98M     0 100% /snap/google-cloud-sdk/126
ubuntu@robotest-a56ae835-node-0:~$ exit
logout
Connection to 34.82.197.133 closed.
walt@work:~/git/robotest/logs/0504-1616/walt/install-1/ubuntu18/overlay2/1n/tf$ vi robotest.tfvars.json
walt@work:~/git/robotest/logs/0504-1616/walt/install-1/ubuntu18/overlay2/1n/tf$ terraform destroy -var-file robotest.tfvars.json
data.template_file.bootstrap: Refreshing state...
data.google_compute_network.robotest: Refreshing state...
data.google_compute_zones.available: Refreshing state...
data.google_compute_subnetwork.robotest: Refreshing state...
random_shuffle.zones: Refreshing state... [id=-]
google_compute_disk.etcd[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0]
google_compute_disk.boot[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0]
google_compute_instance.node[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0]
google_compute_instance_group.robotest: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-b/instanceGroups/robotest-a56ae835-node-group]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # google_compute_disk.boot[0] will be destroyed
  - resource "google_compute_disk" "boot" {
      - creation_timestamp        = "2020-05-04T16:37:32.343-07:00" -> null
      - id                        = "projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0" -> null
      - image                     = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200414" -> null
      - label_fingerprint         = "FO6y_7excmg=" -> null
      - labels                    = {
          - "cluster"  = "robotest-a56ae835"
          - "robotest" = ""
        } -> null
      - last_attach_timestamp     = "2020-05-04T16:37:36.334-07:00" -> null
      - name                      = "robotest-a56ae835-disk-boot-0" -> null
      - physical_block_size_bytes = 4096 -> null
      - project                   = "kubeadm-167321" -> null
      - self_link                 = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0" -> null
      - size                      = 64 -> null
      - source_image_id           = "4603076213173093932" -> null
      - type                      = "pd-ssd" -> null
      - users                     = [
          - "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0",
        ] -> null
      - zone                      = "us-west1-b" -> null
    }

  # google_compute_disk.etcd[0] will be destroyed
  - resource "google_compute_disk" "etcd" {
      - creation_timestamp        = "2020-05-04T16:37:32.509-07:00" -> null
      - id                        = "projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0" -> null
      - label_fingerprint         = "FO6y_7excmg=" -> null
      - labels                    = {
          - "cluster"  = "robotest-a56ae835"
          - "robotest" = ""
        } -> null
      - last_attach_timestamp     = "2020-05-04T16:37:36.339-07:00" -> null
      - name                      = "robotest-a56ae835-disk-etcd-0" -> null
      - physical_block_size_bytes = 4096 -> null
      - project                   = "kubeadm-167321" -> null
      - self_link                 = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0" -> null
      - size                      = 50 -> null
      - type                      = "pd-ssd" -> null
      - users                     = [
          - "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0",
        ] -> null
      - zone                      = "us-west1-b" -> null
    }

  # google_compute_instance.node[0] will be destroyed
  - resource "google_compute_instance" "node" {
      - can_ip_forward          = false -> null
      - cpu_platform            = "Intel Skylake" -> null
      - deletion_protection     = false -> null
      - description             = "Instance is a single robotest cluster node" -> null
      - enable_display          = false -> null
      - guest_accelerator       = [] -> null
      - id                      = "projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0" -> null
      - instance_id             = "4272367021324048848" -> null
      - label_fingerprint       = "FO6y_7excmg=" -> null
      - labels                  = {
          - "cluster"  = "robotest-a56ae835"
          - "robotest" = ""
        } -> null
      - machine_type            = "custom-8-8192" -> null
      - metadata                = {
          - "ssh-keys" = "..."
        } -> null
      - metadata_fingerprint    = "DVWELWEDBG4=" -> null
      - metadata_startup_script = "#!/bin/bash\n#\n# VM bootstrap script for Debian/Ubuntu\n#\nset -exuo pipefail\n\netcd_device_name=sdb\netcd_dir=/var/lib/gravity/planet/etcd\nDIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" >/dev/null && pwd)\"\n\nfunction secure-ssh {\n  local sshd_config=/etc/ssh/sshd_config\n  cp $sshd_config $sshd_config.old\n  (grep -qE '(\\#?)\\WPasswordAuthentication' $sshd_config && \\\n    sed -re 's/^(\\#?)\\W*(PasswordAuthentication)([[:space:]]+)yes/\\2\\3no/' -i $sshd_config) || \\\n    echo 'PasswordAuthentication no' >> $sshd_config\n  (grep -qE '(\\#?)\\WChallengeResponseAuthentication' $sshd_config && \\\n    sed -re 's/^(\\#?)\\W*(ChallengeResponseAuthentication)([[:space:]]+)yes/\\2\\3no/' -i $sshd_config) || \\\n    echo 'ChallengeResponseAuthentication no' >> $sshd_config\n  systemctl reload ssh\n}\n\nfunction remove-sshguard {\n  if systemctl is-active --quiet sshguard; then\n    apt-get -y remove --auto-remove sshguard\n    apt-get -y purge --auto-remove sshguard\n  fi\n}\n\nfunction setup-user {\n  local service_uid=$(id ubuntu -u 2>/dev/null || true)\n  local service_gid=$(id ubuntu -g 2>/dev/null || true)\n\n  if [ -z \"$service_gid\" ]; then\n    service_gid=1000\n    (groupadd --system --non-unique --gid $service_gid ubuntu 2>/dev/null; err=$?; if (( $err != 9 )); then exit $err; fi) || true\n  fi\n\n  if [ -z \"$service_uid\" ]; then\n    service_uid=1000\n    (useradd --system --non-unique --gid $service_gid --uid $service_uid ubuntu 2>/dev/null; err=$?; if (( $err != 9 )); then exit $err; fi) || true\n  fi\n\n  if [ ! -d \"/home/ubuntu/.ssh\" ]; then\n    mkdir -p /home/ubuntu/.ssh\n    echo \"...\" | tee /home/ubuntu/.ssh/authorized_keys\n    chmod 0700 /home/ubuntu/.ssh\n    chmod 0600 /home/ubuntu/.ssh/authorized_keys\n    chsh -s /bin/bash ubuntu\n  fi\n\n  chown -R $service_uid:$service_gid /home/ubuntu\n  sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers\n}\n\ntouch /var/lib/bootstrap_started\n\nmkdir -p $etcd_dir /var/lib/data\n\nremove-sshguard\nsecure-ssh\nsetup-user\n\n# Bump number of retries for download failures\necho \"APT::Acquire::Retries \\\"10\\\";\" > /etc/apt/apt.conf.d/80-retries\n\napt-get update\napt-get install -y chrony lvm2 curl wget thin-provisioning-tools python\n\ncurl https://bootstrap.pypa.io/get-pip.py | python -\npip install --upgrade awscli\n\nif ! grep -qs \"$etcd_dir\" /proc/mounts; then\n  mkfs.ext4 -F /dev/$etcd_device_name\n  sed -i.bak \"/$etcd_device_name/d\" /etc/fstab\n  echo -e \"/dev/$etcd_device_name\\t$etcd_dir\\text4\\tdefaults\\t0\\t2\" >> /etc/fstab\n  mount $etcd_dir\nfi\n\n## Setup modules / sysctls\n# Load required kernel modules\nmodules=\"br_netfilter overlay ebtable_filter ip_tables iptable_filter iptable_nat\"\nfor module in $modules; do\n  modprobe $module || true\ndone\n# Store the modules into a file so that the modules will be auto-reloaded\n# on reboot\necho '' > /etc/modules-load.d/telekube.conf\nfor module in $modules; do\n  echo $module >> /etc/modules-load.d/telekube.conf\ndone\n\n# Make changes permanent\ncat > /etc/sysctl.d/50-telekube.conf <<EOF\nnet.ipv4.ip_forward=1\nnet.bridge.bridge-nf-call-iptables=1\nnet.ipv4.tcp_keepalive_time=60\nnet.ipv4.tcp_keepalive_intvl=60\nnet.ipv4.tcp_keepalive_probes=5\nEOF\nsysctl -p /etc/sysctl.d/50-telekube.conf\n\n# Mark bootstrap step complete for robotest\ntouch /var/lib/bootstrap_complete\n" -> null
      - min_cpu_platform        = "Intel Skylake" -> null
      - name                    = "robotest-a56ae835-node-0" -> null
      - project                 = "kubeadm-167321" -> null
      - self_link               = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0" -> null
      - tags                    = [
          - "robotest",
          - "robotest-a56ae835-node-0",
        ] -> null
      - tags_fingerprint        = "EjMfebD22Iw=" -> null
      - zone                    = "us-west1-b" -> null

      - attached_disk {
          - device_name = "persistent-disk-1" -> null
          - mode        = "READ_WRITE" -> null
          - source      = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0" -> null
        }

      - boot_disk {
          - auto_delete = true -> null
          - device_name = "persistent-disk-0" -> null
          - mode        = "READ_WRITE" -> null
          - source      = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0" -> null

          - initialize_params {
              - image  = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200414" -> null
              - labels = {
                  - "cluster"  = "robotest-a56ae835"
                  - "robotest" = ""
                } -> null
              - size   = 64 -> null
              - type   = "pd-ssd" -> null
            }
        }

      - network_interface {
          - name               = "nic0" -> null
          - network            = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/global/networks/robotest" -> null
          - network_ip         = "10.138.0.14" -> null
          - subnetwork         = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/regions/us-west1/subnetworks/robotest" -> null
          - subnetwork_project = "kubeadm-167321" -> null

          - access_config {
              - nat_ip       = "34.82.197.133" -> null
              - network_tier = "PREMIUM" -> null
            }
        }

      - scheduling {
          - automatic_restart   = true -> null
          - on_host_maintenance = "MIGRATE" -> null
          - preemptible         = false -> null
        }

      - service_account {
          - email  = "..." -> null
          - scopes = [
              - "https://www.googleapis.com/auth/compute",
              - "https://www.googleapis.com/auth/devstorage.read_only",
              - "https://www.googleapis.com/auth/servicecontrol",
            ] -> null
        }

      - shielded_instance_config {
          - enable_integrity_monitoring = true -> null
          - enable_secure_boot          = false -> null
          - enable_vtpm                 = true -> null
        }
    }

  # google_compute_instance_group.robotest will be destroyed
  - resource "google_compute_instance_group" "robotest" {
      - description = "Instance group controlling instances of a single robotest cluster" -> null
      - id          = "projects/kubeadm-167321/zones/us-west1-b/instanceGroups/robotest-a56ae835-node-group" -> null
      - instances   = [
          - "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0",
        ] -> null
      - name        = "robotest-a56ae835-node-group" -> null
      - network     = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/global/networks/robotest" -> null
      - project     = "kubeadm-167321" -> null
      - self_link   = "https://www.googleapis.com/compute/v1/projects/kubeadm-167321/zones/us-west1-b/instanceGroups/robotest-a56ae835-node-group" -> null
      - size        = 1 -> null
      - zone        = "us-west1-b" -> null
    }

  # random_shuffle.zones will be destroyed
  - resource "random_shuffle" "zones" {
      - id           = "-" -> null
      - input        = [
          - "us-west1-a",
          - "us-west1-b",
          - "us-west1-c",
        ] -> null
      - result       = [
          - "us-west1-b",
        ] -> null
      - result_count = 1 -> null
    }

Plan: 0 to add, 0 to change, 5 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

google_compute_instance_group.robotest: Destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instanceGroups/robotest-a56ae835-node-group]
google_compute_instance_group.robotest: Destruction complete after 3s
google_compute_instance.node[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 10s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 20s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 30s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 40s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 50s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 1m0s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 1m10s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-b/instances/robotest-a56ae835-node-0, 1m20s elapsed]
google_compute_instance.node[0]: Destruction complete after 1m29s
google_compute_disk.boot[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-boot-0]
google_compute_disk.etcd[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-b/disks/robotest-a56ae835-disk-etcd-0]
google_compute_disk.boot[0]: Destruction complete after 0s
google_compute_disk.etcd[0]: Destruction complete after 4s
random_shuffle.zones: Destroying... [id=-]
random_shuffle.zones: Destruction complete after 0s

Destroy complete! Resources: 5 destroyed.

</pre>
</details>

## Additional information
<!--Optional. Anything else that may be relevant.-->
