### PR TITLE
shrink research

### DIFF
--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -26,7 +26,7 @@ const (
 type lossAndRecoveryParam struct {
 	installParam
 	// ReplaceNodeType : see killXXX constants
-	ReplaceNodeType string `json:"kill" validate:"required,eq=apimaster|clmaster|clbackup|worker"`
+	ReplaceNodeType string `json:"kill" validate:"required,oneof=apimaster clmaster clbackup worker"`
 	// ExpandBeforeShrink is whether to expand cluster before removing dead node
 	ExpandBeforeShrink bool `json:"expand_before_shrink" validate:"required"`
 	// PowerOff is whether to power off node before remove

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -71,16 +71,16 @@ func lossAndRecoveryVariety(p interface{}) (gravity.TestFunc, error) {
 func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 	param := p.(lossAndRecoveryParam)
 
-	return func(g *gravity.TestContext, baseConfig gravity.ProvisionerConfig) {
-		config := baseConfig.WithNodes(param.NodeCount + 1)
+	return func(g *gravity.TestContext, cfg gravity.ProvisionerConfig) {
+		cfg = cfg.WithNodes(param.NodeCount + 1)
 
-		cluster, err := g.Provision(config)
+		cluster, err := g.Provision(cfg)
 		g.OK("provision nodes", err)
 		defer func() {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		g.OK("download installer", g.SetInstaller(cluster.Nodes, config.InstallerURL, "install"))
+		g.OK("download installer", g.SetInstaller(cluster.Nodes, cfg.InstallerURL, "install"))
 
 		nodes := cluster.Nodes[0:param.NodeCount]
 		g.OK("install", g.OfflineInstall(nodes, param.InstallParam))

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -74,7 +74,7 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 	return func(g *gravity.TestContext, cfg gravity.ProvisionerConfig) {
 		cfg = cfg.WithNodes(param.NodeCount + 1)
 
-		cluster, err := g.Provision(cfg)
+		cluster, err := provisionNodes(g, cfg, param.installParam)
 		g.OK("provision nodes", err)
 		defer func() {
 			g.Maybe("destroy", cluster.Destroy())

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -28,9 +28,9 @@ type lossAndRecoveryParam struct {
 	// ReplaceNodeType : see killXXX constants
 	ReplaceNodeType string `json:"kill" validate:"required,oneof=apimaster clmaster clbackup worker"`
 	// ExpandBeforeShrink is whether to expand cluster before removing dead node
-	ExpandBeforeShrink bool `json:"expand_before_shrink" validate:"required"`
+	ExpandBeforeShrink bool `json:"expand_before_shrink"`
 	// PowerOff is whether to power off node before remove
-	PowerOff bool `json:"pwroff_before_remove" validate:"required"`
+	PowerOff bool `json:"pwroff_before_remove"`
 }
 
 func lossAndRecoveryVariety(p interface{}) (gravity.TestFunc, error) {


### PR DESCRIPTION
## Description
This PR contains minor cleanup necessary to run the formerly defunct `recover` test case, which was unofficially deprecated/broken by the work in #134 .

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* Regression fix (non-breaking change which fixes a regression)

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/robotest/issues/188

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Write documentation
- [x] Address review feedback

## Testing done
Before this test case would always fail with `trace.BadParameterError unknown OS vendor: ""` as seen [here](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-05T06:22:16.581000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2214f4bf5d-41b8-451e-b2fa-369dbad319b5%22%0Alabels.__suite__%3D%224ead932c-cd7f-4a13-922a-c4368cdd915c%22%0Aseverity%3E%3DINFO&dateRangeEnd=2020-05-05T06:22:14.446Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2020-05-01T19:00:29.475580974Z).

Now it has timing/timeout issues as seen [here](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-04T21:46:34.045000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-05-04T18:21:18.296Z&interval=CUSTOM&scrollTimestamp=2020-05-04T19:11:21.765592594Z&dateRangeEnd=2020-05-04T19:21:18.296Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%229d2c5f6a-1264-4bf8-986d-b0d764f2b6e0%22%0Alabels.__suite__%3D%222456dddf-c10c-4e17-8ff9-c16eacbf8c25%22%0Aseverity%3E%3DINFO).  I'd like to address these in this PR, but I got widly distracted by #209 and #210 along the way.


