### PR TITLE
Import lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - goimports

--- a/infra/gravity/provision.go
+++ b/infra/gravity/provision.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/dustin/go-humanize"
 	"github.com/gravitational/trace"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/gravitational/trace"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 

--- a/infra/infra.go
+++ b/infra/infra.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/robotest/lib/loc"
-	"github.com/gravitational/robotest/lib/ssh"
+	sshutils "github.com/gravitational/robotest/lib/ssh"
 	"github.com/gravitational/robotest/lib/wait"
 
 	"github.com/gravitational/trace"


### PR DESCRIPTION
## Description
This PR causes `make lint` to enforce `goimports` compatibility.

After the discussion at https://github.com/gravitational/robotest/pull/209#discussion_r419988351 I want to automate review that a machine can take care of so that I don't waste human reviewer time on it.

## Type of change
* Internal change (not necessarily a bug fix or a new feature)
* This change has a developer-facing impact

## Linked tickets and other PRs
* Contributes to https://github.com/gravitational/robotest/issues/171

## TODOs
- [x] Self-review the change
- [x] Perform manual testing
- [x] Address review feedback

## Testing done
Before the 2nd commit:
```
walt@work:~/git/robotest$ make lint        
docker build --pull --tag robotest:buildbox \
	--build-arg UID=$(id -u) \
	--build-arg GID=$(id -g) \
	--build-arg GOLANGCI_LINT_VER=1.21.0 \
	docker/build
// snip ...
Successfully built fdb1bf1a6b37
Successfully tagged robotest:buildbox
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest \
	--env="GO111MODULE=off" \
	robotest:buildbox dumb-init golangci-lint run \
	--skip-dirs=vendor \
	--timeout=2m
infra/infra.go:13: File is not `goimports`-ed (goimports)
	"github.com/gravitational/robotest/lib/ssh"
infra/gravity/provision.go:29: File is not `goimports`-ed (goimports)
	"github.com/satori/go.uuid"
infra/gravity/testsuite.go:18: File is not `goimports`-ed (goimports)
	"github.com/satori/go.uuid"
make: *** [Makefile:65: lint] Error 1
```
After the cleanup:
```
walt@work:~/git/robotest$ time make lint
docker build --pull --tag robotest:buildbox \
	--build-arg UID=$(id -u) \
	--build-arg GID=$(id -g) \
	--build-arg GOLANGCI_LINT_VER=1.21.0 \
	docker/build
// snip ..
Successfully built fdb1bf1a6b37
Successfully tagged robotest:buildbox
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest \
	--env="GO111MODULE=off" \
	robotest:buildbox dumb-init golangci-lint run \
	--skip-dirs=vendor \
	--timeout=2m
make lint  0.31s user 0.10s system 1% cpu 25.810 total
```

## Additional information
I looked for a way to catch the `snake_case` variables too.  The thing that looked the most reasonable was enabling the `golint` check, but it also nagged about a bunch of other stuff latent in the codebase.
<details>
<summary>golint nags</summary>
<pre>
walt@work:~/git/robotest$ golangci-lint run --disable-all --enable golint
e2e/framework/applications.go:23:2: should not use dot imports (golint)
	. "github.com/onsi/gomega"
	^
e2e/framework/framework.go:18:2: should not use dot imports (golint)
	. "github.com/onsi/ginkgo"
	^
e2e/framework/framework.go:19:2: should not use dot imports (golint)
	. "github.com/onsi/gomega"
	^
suite/sanity/install.go:18:2: struct field `Url` should be `URL` (golint)
	Url  string   `json:"url" validate:"required"`
	^
suite/sanity/loss_recover.go:17:2: const `nodeApiMaster` should be `nodeAPIMaster` (golint)
	nodeApiMaster = "apimaster"
	^
infra/vagrant/vagrant.go:28:43: exported func New returns unexported type *github.com/gravitational/robotest/infra/vagrant.vagrant, which can be annoying to use (golint)
func New(stateDir string, config Config) (*vagrant, error) {
                                          ^
infra/vagrant/vagrant.go:41:71: exported func NewFromState returns unexported type *github.com/gravitational/robotest/infra/vagrant.vagrant, which can be annoying to use (golint)
func NewFromState(config Config, stateConfig infra.ProvisionerState) (*vagrant, error) {
                                                                      ^
e2e/uimodel/site/siteservers.go:24:6: type name will be used as site.SiteServer by other packages, and that stutters; consider calling this Server (golint)
type SiteServer struct {
     ^
e2e/uimodel/site/siteservers.go:212:40: method parameter `serverId` should be `serverID` (golint)
func (p *ServerPage) clickDeleteServer(serverId string) {
                                       ^
infra/agents.go:173:10: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
		} else {
		       ^
infra/node_pool.go:7:50: exported func NewNodePool returns unexported type *github.com/gravitational/robotest/infra.nodePool, which can be annoying to use (golint)
func NewNodePool(nodes []Node, alloced []string) *nodePool {
                                                 ^
infra/gravity/cluster_install.go:32:53: method parameter `installerUrl` should be `installerURL` (golint)
func (c *TestContext) SetInstaller(nodes []Gravity, installerUrl string, tag string) error {
                                                    ^
infra/gravity/cluster_install.go:234:51: method parameter `scriptUrl` should be `scriptURL` (golint)
func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []string) error {
                                                  ^
infra/gravity/cluster_status.go:123:2: struct field `ApiMaster` should be `APIMaster` (golint)
	ApiMaster Gravity
	^
infra/gravity/node_commands.go:33:36: interface method parameter `installerUrl` should be `installerURL` (golint)
	SetInstaller(ctx context.Context, installerUrl, subdir string) error
	                                  ^
infra/gravity/node_commands.go:40:34: interface method parameter `scriptUrl` should be `scriptURL` (golint)
	ExecScript(ctx context.Context, scriptUrl string, args []string) error
	                                ^
infra/gravity/node_commands.go:46:37: interface method parameter `installerUrl` should be `installerURL` (golint)
	OfflineUpdate(ctx context.Context, installerUrl string) error
	                                   ^
infra/gravity/node_commands.go:134:6: type name will be used as gravity.GravityStatus by other packages, and that stutters; consider calling this Status (golint)
type GravityStatus struct {
     ^
infra/gravity/node_commands.go:325:54: method parameter `installerUrl` should be `installerURL` (golint)
func (g *gravity) OfflineUpdate(ctx context.Context, installerUrl string) error {
                                                     ^
infra/gravity/node_commands.go:522:51: method parameter `scriptUrl` should be `scriptURL` (golint)
func (g *gravity) ExecScript(ctx context.Context, scriptUrl string, args []string) error {
                                                  ^
infra/gravity/node_utils.go:12:5: var `reIpAddr` should be `reIPAddr` (golint)
var reIpAddr = regexp.MustCompile(`(([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3}))`)
    ^
infra/gravity/testcontext.go:73:1: receiver name c should be consistent with previous receiver name cx for TestContext (golint)
func (c *TestContext) Context() context.Context {
^
infra/gravity/testcontext.go:78:1: receiver name c should be consistent with previous receiver name cx for TestContext (golint)
func (c *TestContext) Logger() logrus.FieldLogger {
^
infra/gravity/testcontext.go:86:1: receiver name c should be consistent with previous receiver name cx for TestContext (golint)
func (c *TestContext) SetTimeouts(tm OpTimeouts) {
^
infra/gravity/testcontext.go:247:9: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
	} else {
	       ^
infra/gravity/testsuite.go:57:2: struct field `LogUrl` should be `LogURL` (golint)
	LogUrl        string
	^
infra/gravity/testsuite.go:153:2: var `longUrl` should be `longURL` (golint)
	longUrl := url.URL{
	^
infra/gravity/testsuite.go:363:2: should replace `r.numPreempted += 1` with `r.numPreempted++` (golint)
	r.numPreempted += 1
	^
infra/gravity/testsuite.go:370:2: should replace `r.numTries += 1` with `r.numTries++` (golint)
	r.numTries += 1
	^
lib/ssh/files.go:18:84: func parameter `fileUrl` should be `fileURL` (golint)
func TransferFile(ctx context.Context, client *ssh.Client, log logrus.FieldLogger, fileUrl, dstDir string, env map[string]string) (path string, err error) {
                                                                                   ^
lib/ssh/time.go:21:6: type `SshNode` should be `SSHNode` (golint)
type SshNode struct {
     ^
infra/providers/azure/azure.go:15:2: struct field `ClientId` should be `ClientID` (golint)
	ClientId, ClientSecret, TenantId string
	^
infra/providers/azure/config.go:6:2: struct field `SubscriptionId` should be `SubscriptionID` (golint)
	SubscriptionId string `json:"subscription_id" yaml:"subscription_id" validate:"required"`
	^
infra/providers/azure/config.go:8:2: struct field `ClientId` should be `ClientID` (golint)
	ClientId string `json:"client_id" yaml:"client_id" validate:"required"`
	^
infra/providers/azure/config.go:12:2: struct field `TenantId` should be `TenantID` (golint)
	TenantId string `json:"tenant_id" yaml:"tenant_id" validate:"required"`
	^
infra/providers/azure/config.go:20:2: struct field `VmType` should be `VMType` (golint)
	VmType string `json:"vm_type" yaml:"vm_type" validate:"required"`
	^
lib/config/config.go:17:6: type name will be used as config.ConfigFn by other packages, and that stutters; consider calling this Fn (golint)
type ConfigFn func(param interface{}) (gravity.TestFunc, error)
     ^
e2e/uimodel/agent/agent.go:15:6: type name will be used as agent.AgentServer by other packages, and that stutters; consider calling this Server (golint)
type AgentServer struct {
     ^
lib/debug/profile.go:5:2: a blank import should be only in a main or test package, or have a comment justifying it (golint)
	_ "net/http/pprof"
	^
infra/terraform/file_transfer.go:16:39: method parameter `fileUrl` should be `fileURL` (golint)
func (t *terraform) makeRemoteCommand(fileUrl, command string) (string, error) {
                                      ^
infra/terraform/terraform.go:33:43: exported func New returns unexported type *github.com/gravitational/robotest/infra/terraform.terraform, which can be annoying to use (golint)
func New(stateDir string, config Config) (*terraform, error) {
                                          ^
infra/terraform/terraform.go:53:71: exported func NewFromState returns unexported type *github.com/gravitational/robotest/infra/terraform.terraform, which can be annoying to use (golint)
func NewFromState(config Config, stateConfig infra.ProvisionerState) (*terraform, error) {
                                                                      ^
lib/xlog/google_cloud_log.go:103:1: receiver name c should be consistent with previous receiver name client for GCLClient (golint)
func (c *GCLClient) Context() context.Context {
^
lib/xlog/google_cloud_log.go:108:1: receiver name c should be consistent with previous receiver name client for GCLClient (golint)
func (c *GCLClient) Hook(name string, fields logrus.Fields) *GCLHook {
^
lib/xlog/google_cloud_log.go:134:1: receiver name c should be consistent with previous receiver name client for GCLClient (golint)
func (c GCLClient) Topic() *pubsub.Topic {
^
lib/wait/retry.go:67:31: should replace `i += 1` with `i++` (golint)
	for i := 1; i <= r.Attempts; i += 1 {
	                             ^
lib/wait/retry.go:135:9: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
	} else {
	       ^
e2e/uimodel/utils/utils.go:45:6: func FormatUrl should be FormatURL (golint)
func FormatUrl(page *web.Page, prefix string) string {

</pre>
</details>

I think it is probably a good idea to clean these up and enable this.  But I also notice we don't follow golint elsewhere (yet).  @awly's work in teleport is the closet point of comparison and here are the check's they're running:

https://github.com/gravitational/teleport/blob/84d438fcf633a864174bbbe7f7f6f92f97ecea16/Makefile#L28
