### PR TITLE
Allow `upgrade3lts` as an alternative form of `upgrade`.

### DIFF
--- a/suite/sanity/sanity.go
+++ b/suite/sanity/sanity.go
@@ -24,6 +24,11 @@ func Suite() *config.Config {
 	cfg.Add("recover", lossAndRecovery, lossAndRecoveryParam{installParam: defaultInstallParam})
 	cfg.Add("recoverV", lossAndRecoveryVariety, defaultInstallParam)
 	cfg.Add("upgrade", upgrade, upgradeParam{installParam: defaultInstallParam})
+	// upgrade3lts is vestigial alias for upgrade needed for backwards compat
+	// to prevent issues like:
+	//   https://github.com/gravitational/gravity/issues/1508
+	// consider removing at the next semver major version bump -- 2020-05 walt
+	cfg.Add("upgrade3lts", upgrade, upgradeParam{installParam: defaultInstallParam})
 	cfg.Add("autoscale", autoscale, defaultInstallParam)
 
 	return cfg


### PR DESCRIPTION
I made a mistake when I removed the ability to specify upgrade tests
via upgrade3lts in c0540aa9bae1c8ad49fc61fd0e541b018bdd0c37.

The new 'upgrade' syntax is cleaner, but we've seen multiple occasions
where consumers of robotest fail to update the syntax at the same time
as they update robotest:

 - https://github.com/gravitational/gravity/issues/1315
 - https://github.com/gravitational/gravity/issues/1508

Lets be kind to robotest consumers and support both options for a
period. We can then remove the `upgrade3lts` syntax later when we're
more confident nothing is still using it.

## Testing Done
```
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=<redacted> -test.parallel=1 -repeat=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0506-2131/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug '-provision=
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.4/linux/x86_64/telekube-7.0.4-linux-x86_64.tar
gravity_url: /home/walt/go/bin/gravity
script_path: /home/walt/git/robotest/assets/terraform/gce
tf_plugin_dir: /home/walt/.terraform.d/plugins/linux_amd64
state_dir: /home/walt/git/robotest/logs/0506-2131
cloud: gce
aws:
  access_key: <redacted>
  secret_key: <redacted>
  region: us-east-1
  ssh_user: unused
  key_path: unused
  key_pair: unused
  docker_device: unused
  vpc: unused
gce:
  credentials: <redacted>
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /home/walt/.ssh/robotest
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub
  var_file_path: /home/walt/git/robotest/logs/0506-2131/gcp-vars.json
' 'upgrade3lts={"nodes":1,"flavor":"one","os":"ubuntu:18","storage_driver":"overlay2","role":"node","from":"s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.0/linux/x86_64/telekube-7.0.0-linux-x86_64.tar"}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060              
INFO RUNNING                                       logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22261df08f-9812-412d-8cc4-dcef6debbb6c%22%0Alabels.__suite__%3D%2249b80b5f-0509-4e94-a8b5-84e5a9724d8b%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-upgrade3lts-1 param="{"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"ubuntu","Version":"18"},"storage_driver":"overlay2","nodes":1,"script":null,"from":"s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.0/linux/x86_64/telekube-7.0.0-linux-x86_64.tar"}" where=[/retry.go:36]
```