### PR TITLE
Add version & commit information to logs.

### DIFF
--- a/infra/gravity/testcontext.go
+++ b/infra/gravity/testcontext.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gravitational/robotest"
 	"github.com/gravitational/robotest/lib/xlog"
 
 	"cloud.google.com/go/bigquery"
@@ -217,7 +218,12 @@ func (msg progressMessage) Save() (row map[string]bigquery.Value, insertID strin
 func (c *TestContext) updateStatus(status string) {
 	c.status = status
 
-	log := c.Logger().WithFields(logrus.Fields{"param": xlog.ToJSON(c.param), "name": c.name})
+	log := c.Logger().WithFields(logrus.Fields{
+		"param":   xlog.ToJSON(c.param),
+		"name":    c.name,
+		"version": robotest.Version,
+		"commit":  robotest.GitCommit,
+	})
 	switch c.status {
 	case TestStatusScheduled, TestStatusRunning:
 		log.Info(c.status)

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -78,6 +78,9 @@ func TestMain(t *testing.T) {
 		debug.StartProfiling(fmt.Sprintf("localhost:%v", *debugPort))
 	}
 
+	log.Debugf("Version:\t%s", robotest.Version)
+	log.Debugf("Git Commit:\t%s", robotest.GitCommit)
+
 	config := gravity.LoadConfig(t, []byte(*provision))
 	config = config.WithTag(*tag)
 


### PR DESCRIPTION
With #206 merged and version/commit information available within the go runtime, I now want to make sure that this info is recorded & accessible for all robotest runs.

Immediately, this is motivated by trying & failing to RCA https://github.com/gravitational/robotest/issues/214#issuecomment-625551626

I'd love to be able to make sure I'm running the exact same version.  I recognize this pach won't help with #214 because the cause predates all the version work.  But maybe it'll help me next time.

## Testing Done
Via the console:

```
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=<redacted> -test.parallel=1 -repeat=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0507-1831/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug '-provision=
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.4/linux/x86_64/telekube-7.0.4-linux-x86_64.tar
gravity_url: /home/walt/go/bin/gravity
script_path: /home/walt/git/robotest/assets/terraform/gce
tf_plugin_dir: /home/walt/.terraform.d/plugins/linux_amd64
state_dir: /home/walt/git/robotest/logs/0507-1831
cloud: gce
aws:
  access_key: <redacted>
  secret_key: <redacted>
  region: us-east-1
  ssh_user: unused
  key_path: unused
  key_pair: unused
  docker_device: unused
  vpc: unused
gce:
  credentials: <redacted>
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /home/walt/.ssh/robotest
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub
  var_file_path: /home/walt/git/robotest/logs/0507-1831/gcp-vars.json
' 'noop={"nodes":1,"flavor":"one","os":"ubuntu:18","storage_driver":"overlay2","role":"node"}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060              
DEBU[0000] Version:	1.0.1-dev.235+725c978c              
DEBU[0000] Git Commit:	725c978c75b1883fa96c860851c595d0ab1bf424
INFO RUNNING                                       commit=725c978c75b1883fa96c860851c595d0ab1bf424 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%224a9456c9-a92e-4259-bf2b-5bbeaaa691ed%22%0Alabels.__suite__%3D%2246b3e7b4-3f25-4ba5-96d0-0cb05432cc07%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":0,"fail":false}" version="1.0.1-dev.235+725c978c" where=[/retry.go:36]

```

And in [stackdriver logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-08T01:13:08.260000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2235519b16-2972-4414-ada0-a77a3a1a066e%22%0Alabels.__suite__%3D%22934677cc-83ff-4329-a8a1-c512cd49f97e%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-08T00:13:08.832Z&dateRangeEnd=2020-05-08T01:13:08.832Z&interval=PT1H&scrollTimestamp=2020-05-08T01:00:15.162600856Z)

```
 jsonPayload: {
  commit: "725c978c75b1883fa96c860851c595d0ab1bf424"   
  logs: "https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2235519b16-2972-4414-ada0-a77a3a1a066e%22%0Alabels.__suite__%3D%22934677cc-83ff-4329-a8a1-c512cd49f97e%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321"   
  message: "RUNNING"   
  name: "walt-install-1"   
  param: "{"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7"},"storage_driver":"overlay2","nodes":1,"script":null}"   
  
stack: [
   0: "/retry.go:36"    
   1: "/lib/wait/retry.go:113"    
  ]
  version: "1.0.1-dev.235+725c978c"   
 }
```
