### PR TITLE
Disable the epel repository to minimize bootstrap failures

### DIFF
--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -71,7 +71,11 @@ if [ $dns_running -eq 0 ] ; then
   systemctl disable dnsmasq
 fi
 
-yum install -y chrony python unzip
+# According to https://stackoverflow.com/a/27667111, this is a certificate issue.
+# Although not conclusive, disabling the epel repository for the install as well
+# as the packages being installed are all from the base repository
+yum --disablerepo=epel -y update ca-certificates
+yum --disablerepo=epel -y install chrony python unzip
 
 if ! aws --version; then
   curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"


### PR DESCRIPTION
Disable epel repository to minimize access failures during `yum update` encountered frequently during bootstrapping a node.
Although I attempted to research the reason for the access failure:
```
yum install -y chrony python unzip

One of the configured repositories failed (Unknown),
and yum doesn't have enough cached data to continue. At this point the only
safe thing yum can do is fail. There are a few ways to work "fix" this:
1. Contact the upstream for the repository and get them to fix the problem.
2. Reconfigure the baseurl/etc. for the repository, to point to a working
upstream. This is most often useful if you are using a newer
distribution release than is supported by the repository (and the
packages for the previous distribution release still work).
3. Run the command with the repository temporarily disabled
yum --disablerepo=<repoid> ...
4. Disable the repository permanently, so yum won't use it by default. Yum
will then just ignore the repository until you permanently enable it
again or use --enablerepo for temporary usage:
yum-config-manager --disable <repoid>
or
subscription-manager repos --disable=<repoid>
5. Configure the failing repository to be skipped, if it is unavailable.
Note that yum will try to contact the repo. when it runs most commands,
so will have to try and fail each time (and thus. yum will be be much
slower). If it is a very temporary problem though, this is often a nice
compromise:
yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
Cannot retrieve metalink for repository: epel/x86_64. Please verify its path and try again
Return code 1.
Finished running startup scripts.
```
I only found [this](https://stackoverflow.com/a/27667111) SO thread which seems relevant.
In addition to attempting to update the certificate package this also skips the `epel` repository from the `install` command as all the packages being installed are from the `base` repository.

Updates https://github.com/gravitational/robotest/issues/214.
Robotest [logs](https://jenkins.gravitational.io/job/Gravity-PR-5.2/job/PR-1538/1/consoleText).
Stackdriver [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&angularJsUrl=%2Flogs%2Fviewer%3FadvancedFilter%3Dresource.type%253D%2522project%2522%250Alabels.__uuid__%253D%252261e5689a-7af2-4bad-a007-2509e002da39%2522%250Alabels.__suite__%253D%2522b17b7c66-8020-4a17-acf7-a3f5dd824108%2522%250Aseverity%253E%253DINFO%26authuser%3D1%26expandAll%3Dfalse%26project%3Dkubeadm-167321&minLogLevel=0&timestamp=2020-05-11T09:02:22.671000000Z&customFacets=&limitCustomFacetWidth=true&interval=NO_LIMIT&scrollTimestamp=2020-05-10T15:23:27.788737152Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2261e5689a-7af2-4bad-a007-2509e002da39%22%0Alabels.__suite__%3D%22b17b7c66-8020-4a17-acf7-a3f5dd824108%22%0A%22startup-script%22).

### Testing done
Removed and reinstalled packages without the repository. Note, this was not possible for python being the direct dependency for `yum` itself.