### PR TITLE
Break out of bootstrap wait loop on failure

### DIFF
--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -18,9 +18,9 @@ DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 function exit_handler {
   if [[ $? -ne 0 ]]; then
-    touch -f bootstrap_failed
+    touch -f /var/lib/bootstrap_failed
   else
-    touch -f bootstrap_complete
+    touch -f /var/lib/bootstrap_complete
   fi
 }
 

--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -2,11 +2,27 @@
 #
 # VM bootstrap script for CentOS/RHEL
 #
-set -exuo pipefail
+set -o errexit
+set -o errtrace
+set -o xtrace
+set -o nounset
+set -o pipefail
+
+rm -f /var/lib/bootstrap_*
+touch /var/lib/bootstrap_started
+trap exit_handler EXIT
 
 etcd_device_name=sdb
 etcd_dir=/var/lib/gravity/planet/etcd
 DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+function exit_handler {
+  if [[ $? -ne 0 ]]; then
+    touch -f bootstrap_failed
+  else
+    touch -f bootstrap_complete
+  fi
+}
 
 function retry {
   local count=0
@@ -57,8 +73,6 @@ function setup-user {
   chown -R $service_uid:$service_gid /home/${os_user}
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
-
-touch /var/lib/bootstrap_started
 
 mkdir -p $etcd_dir /var/lib/data
 secure-ssh
@@ -113,6 +127,3 @@ net.ipv4.tcp_keepalive_intvl=60
 net.ipv4.tcp_keepalive_probes=5
 EOF
 sysctl -p /etc/sysctl.d/50-telekube.conf
-
-# Mark bootstrap step complete for robotest
-touch /var/lib/bootstrap_complete

--- a/assets/terraform/gce/bootstrap/suse.sh
+++ b/assets/terraform/gce/bootstrap/suse.sh
@@ -18,9 +18,9 @@ DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 function exit_handler {
   if [[ $? -ne 0 ]]; then
-    touch -f bootstrap_failed
+    touch -f /var/lib/bootstrap_failed
   else
-    touch -f bootstrap_complete
+    touch -f /var/lib/bootstrap_complete
   fi
 }
 

--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -18,9 +18,9 @@ DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
 function exit_handler {
   if [[ $? -ne 0 ]]; then
-    touch -f bootstrap_failed
+    touch -f /var/lib/bootstrap_failed
   else
-    touch -f bootstrap_complete
+    touch -f /var/lib/bootstrap_complete
   fi
 }
 

--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -2,11 +2,27 @@
 #
 # VM bootstrap script for Debian/Ubuntu
 #
-set -exuo pipefail
+set -o errexit
+set -o errtrace
+set -o xtrace
+set -o nounset
+set -o pipefail
+
+rm -f /var/lib/bootstrap_*
+touch /var/lib/bootstrap_started
+trap exit_handler EXIT
 
 etcd_device_name=sdb
 etcd_dir=/var/lib/gravity/planet/etcd
 DIR="$(cd "$(dirname "$${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+function exit_handler {
+  if [[ $? -ne 0 ]]; then
+    touch -f bootstrap_failed
+  else
+    touch -f bootstrap_complete
+  fi
+}
 
 function secure-ssh {
   local sshd_config=/etc/ssh/sshd_config
@@ -53,8 +69,6 @@ function setup-user {
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
 
-touch /var/lib/bootstrap_started
-
 mkdir -p $etcd_dir /var/lib/data
 
 remove-sshguard
@@ -99,6 +113,3 @@ net.ipv4.tcp_keepalive_intvl=60
 net.ipv4.tcp_keepalive_probes=5
 EOF
 sysctl -p /etc/sysctl.d/50-telekube.conf
-
-# Mark bootstrap step complete for robotest
-touch /var/lib/bootstrap_complete


### PR DESCRIPTION
When awaiting for bootstrap script to complete, take a failed bootstrap state file into account to fail faster.

Fixes https://github.com/gravitational/robotest/issues/218.

Haven't done any testing yet.