### PR TITLE
Switch fetch severity from ERR -> INFO.

### DIFF
--- a/infra/gravity/terraform.go
+++ b/infra/gravity/terraform.go
@@ -81,7 +81,7 @@ func wrapDestroyFunc(c *TestContext, tag string, nodes []Gravity, destroy func(c
 			log.Debug("Collecting logs from nodes...")
 			err := c.CollectLogs("postmortem", nodes)
 			if err != nil {
-				log.WithError(err).Warn("Failed to collect node logs.")
+				log.WithError(err).Warn("Failed to collect logs from at least one node.")
 			}
 		}
 


### PR DESCRIPTION
This patch addresses a pet annoyance of mine. During cleanup on a failed
robotest run, the "Fetching node logs" logging statements show up as
errors when in reality they're running to completion as expected.

I also refactored logic surrounding the handling of apiserver logging to
clarify intent.  The special treatment of the first item of a was
confusing without the additional context that the first item was the
kubernetes api-server.

### Testing Done
[Logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-12T01:45:00.684000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d6e7b0ba-489d-457f-a10a-64d582a2c290%22%0Alabels.__suite__%3D%228a8f3ac0-dc17-44cc-ac91-7c2bd3567387%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-12T00:45:25.455Z&interval=PT1H&scrollTimestamp=2020-05-12T01:28:47.529225930Z&dateRangeEnd=2020-05-12T01:45:25.455Z) when everything collects

[Logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-12T03:44:53.329000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22acf46b21-3e10-4b85-a605-77a105d50a83%22%0Alabels.__suite__%3D%226ae85990-6de8-4bc8-809a-fc913ab69c9f%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-12T02:44:53.757Z&dateRangeEnd=2020-05-12T03:44:53.757Z&interval=PT1H&scrollTimestamp=2020-05-12T03:28:41.880217248Z) when one node fails to collect