### PR TITLE
Conditionally push an extra quay.io image tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GIT_COMMIT := $(shell git rev-parse HEAD)
 VERSIONFILE := version.go
 # docker doesn't allow "+" in image tags: https://github.com/docker/distribution/issues/1201
 DOCKER_VERSION ?= $(subst +,-,$(VERSION))
-TAG ?= latest
 NOROOT := -u $$(id -u):$$(id -g)
 SRCDIR := /go/src/github.com/gravitational/robotest
 BUILDDIR ?= $(abspath build)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,5 @@
 TARGETS := e2e suite
 DOCKER_REPO := quay.io/gravitational
-TAG ?= latest
 DOCKER_ARGS ?= --pull
 
 GRAVITY_VERSION := 5.5.20
@@ -61,7 +60,10 @@ publish: $(DOCKER_IMG)
 
 .PHONY: $(DOCKER_IMG)
 $(DOCKER_IMG): $(TARGETS)
-	docker tag $@:$(VERSION) $@:$(TAG)
 	docker push $@:$(VERSION)
+ifneq ($(TAG),)
+	docker tag $@:$(VERSION) $@:$(TAG)
 	docker push $@:$(TAG)
+endif
+
 


### PR DESCRIPTION
Previously, `make publish` would unconditionally tag images with the version
*and another* tag, 'latest' if unspecified by the user.

In an effort to reduce the use of floating tags and encourage pinned use
of semantic versions, the build will now skip publishing a 2nd tag unless it
is specified by user/automation calling `make publish`.

This helps us move the TAG parameter in jenkins from a ChoiceParameter that must
have a default to a StringParameter that may be empty.  This should balance the need
for freeform tags (create whatever you want) with official build tags (it is no longer
necessary to create/update a 2nd tag if you don't need it) nicely.

Contributes to #200.

### Testing Done
I found this when I changed the TAG parameter in the jenkins job to be a string, (default empty) and got the following failure: [logs](https://jenkins.gravitational.io/view/Robotest/job/Robotest-publish/540/console)

That can serve as the "before" point of reference.

For an 'after' comparision, here is a push with no tag specified:
<details><summary><code>make publish</code></summary>
<pre>
walt@work:~/git/robotest$ make publish
// snip build ...
Successfully built 65867510854d
Successfully tagged quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
rm -rf "/tmp/tmp.UOR0IEVwIZ"
Built quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
// snip more build ...
Successfully built 33bdfa6703d7
Successfully tagged quay.io/gravitational/robotest-e2e:v2.0.0-alpha.1-dirty
rm -rf "/tmp/tmp.upeLwEkbu0"
Built quay.io/gravitational/robotest-e2e:v2.0.0-alpha.1-dirty
docker push quay.io/gravitational/robotest-e2e:v2.0.0-alpha.1-dirty
docker push quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
The push refers to repository [quay.io/gravitational/robotest-suite]
The push refers to repository [quay.io/gravitational/robotest-e2e]
7f1a3763d458: Preparing
6acd10eb35c9: Preparing
cd19755353e0: Preparing
e1d87ff0790b: Preparing
418009cc9eb0: Preparing
13a01c73934a: Waiting
a4f2270a7916: Waiting
7f1a3763d458: Pushed
6acd10eb35c9: Pushed
83a6b8c087c6: Pushed
c8186f2c912a: Pushed
668277a8442b: Pushed
13a01c73934a: Pushed
a4f2270a7916: Pushed
f3e95010aa2c: Pushing [===============>                                   ]  161.4MB/520.6MB
f3e95010aa2c: Pushed
v2.0.0-alpha.1-dirty: digest: sha256:3da8f5710f6b9b9ca1eeca1d1eaa93d6f0e8f520a4af4edb115c97fb6b995b14 size: 2213
v2.0.0-alpha.1-dirty: digest: sha256:6c23de85d7254d6600815cf04cc5f81775c88b3b4bb031860801336bb3f7c587 size: 1786
make[1]: Leaving directory '/home/walt/git/robotest/docker'
walt@work:~/git/robotest$
</pre>
</details>

And a push with a tag specified:
<details><summary><code>make publish TAG=tag-testing</code></summary>
<pre>
walt@work:~/git/robotest$ make publish TAG=tag-testing
// snip build ...
Successfully built c189ea443e58
Successfully tagged quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
rm -rf "/tmp/tmp.q7d4oouXvN"
Built quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
docker push quay.io/gravitational/robotest-e2e:v2.0.0-alpha.1-dirty
docker push quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty
The push refers to repository [quay.io/gravitational/robotest-e2e]
The push refers to repository [quay.io/gravitational/robotest-suite]
83a6b8c087c6: Preparing
c8186f2c912a: Preparing
668277a8442b: Preparing
140badbcd736: Preparing
a84923d59e28: Preparing
f3e95010aa2c: Waiting
fe788fd06a77: Waiting
a18659181d7e: Waiting
cdea1e59f658: Pushing [==================================================>]  8.192kB
7e763501d724: Pushing [==================================================>]  78.34kB
a18659181d7e: Pushing [>                                                  ]  329.2kB/30.16MB
a18659181d7e: Pushing [====>                                              ]  2.623MB/30.16MB
a84923d59e28: Layer already exists
f3e95010aa2c: Layer already exists
fe788fd06a77: Layer already exists
a4f2270a7916: Layer already exists
377fca72312d: Layer already exists
docker push quay.io/gravitational/robotest-e2e:tag-testing
a18659181d7e: Pushing [===================>                               ]   11.8MB/30.16MB
a18659181d7e: Pushed
7e763501d724: Pushed
668277a8442b: Layer already exists
140badbcd736: Layer already exists
a84923d59e28: Layer already exists
f3e95010aa2c: Layer already exists
fe788fd06a77: Layer already exists
tag-testing: digest: sha256:6c23de85d7254d6600815cf04cc5f81775c88b3b4bb031860801336bb3f7c587 size: 1786
v2.0.0-alpha.1-dirty: digest: sha256:3ebf1e99382212b7eb1db1312de1a23a39e94f3bd3f23b02dfacb561847366d3 size: 2213
docker tag quay.io/gravitational/robotest-suite:v2.0.0-alpha.1-dirty quay.io/gravitational/robotest-suite:tag-testing
docker push quay.io/gravitational/robotest-suite:tag-testing
The push refers to repository [quay.io/gravitational/robotest-suite]
a18659181d7e: Layer already exists
cdea1e59f658: Layer already exists
7e763501d724: Layer already exists
418009cc9eb0: Layer already exists
13a01c73934a: Layer already exists
a4f2270a7916: Layer already exists
377fca72312d: Layer already exists
fe788fd06a77: Layer already exists
tag-testing: digest: sha256:3ebf1e99382212b7eb1db1312de1a23a39e94f3bd3f23b02dfacb561847366d3 size: 2213
make[1]: Leaving directory '/home/walt/git/robotest/docker'
walt@work:~/git/robotest$
</pre>
</details>

These can be seen in the tag history here:
https://quay.io/repository/gravitational/robotest-suite?tab=history
https://quay.io/repository/gravitational/robotest-e2e?tab=history

I will delete all of the above testing tags in quay.io once this PR merges, so as to not litter our official repo with -dirty artifacts.

Interesting things I noted during this testing:
1) we can probably stop building and pushing robotest-e2e until we revive that work.  We're throwing away compute/time building and bits in quay.io, as the current versions are known broken.  These may revive someday (https://github.com/gravitational/robotest/issues/162). I've drafted this as PR #223.

2) Robotest has some build determinism issues.  Two consecutive runs minutes apart with no source changes resulted in different image hashes being pushed to quay.io.  I suspect they're functionally equivalent, but we should be able to reuse a cached version from the first build.  I'll need to dig in a bit further to understand the issues & risks here.
