### PR TITLE
Suppress docker continuation warnings.

### DIFF
--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -17,19 +17,19 @@ RUN \
     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list && \
     apt-get update && \
     apt-get -y install google-chrome-stable xvfb unzip && \
-
+    \
     curl $TF_TARBALL -o terraform.zip && \
     curl ${TF_TARBALL} -o terraform.zip && \
     unzip terraform.zip -d /usr/bin && \
     rm -f terraform.zip && \
     mkdir -p /etc/terraform/plugins && \
-
+    \
     for plugin in $TF_PLUGINS; do \
         curl ${plugin} -o plugin.zip && \
         unzip plugin.zip -d /etc/terraform/plugins && \
         rm -f plugin.zip; \
     done && \
-
+    \
     curl $CHROMEDRIVER_TARBALL -o chromedriver.zip && \
     unzip chromedriver.zip && \
     mv chromedriver /usr/bin && \

--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -26,13 +26,13 @@ RUN curl ${TF_TARBALL} -o terraform.zip && \
     unzip terraform.zip -d /usr/bin && \
     rm -f terraform.zip && \
     mkdir -p /etc/terraform/plugins && \
-
+    \
     for plugin in $TF_PLUGINS; do \
         curl ${plugin} -o plugin.zip && \
         unzip plugin.zip -d /etc/terraform/plugins && \
         rm -f plugin.zip; \
     done && \
-
+    \
     apt-get clean && \
     rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
Without this contemporary docker complains:
```
  [WARNING]: Empty continuation line found in:
      RUN  ...
  [WARNING]: Empty continuation lines will become errors in a future release.
```
As discussed in https://github.com/moby/moby/pull/24725

### Testing Done:
Before:
<details><summary><code>make -C docker e2e suite VERSION=testing</code></summary>
<pre>
walt@work:~/git/robotest$ make -C docker e2e suite VERSION=testing
make: Entering directory '/home/walt/git/robotest/docker'
if [ -z ""/tmp/tmp.zBJaAeB5lU"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.zBJaAeB5lU"/build
cp -r ../assets/terraform "/tmp/tmp.zBJaAeB5lU"
cp -a ../build/robotest-e2e "/tmp/tmp.zBJaAeB5lU"/build/
cp -r e2e/* "/tmp/tmp.zBJaAeB5lU"/
if [ "e2e" = "e2e" ]; then \
  cd "/tmp/tmp.zBJaAeB5lU" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-e2e:testing . ; \
else \
  cd "/tmp/tmp.zBJaAeB5lU" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-e2e:testing . ; \
fi
Sending build context to Docker daemon  17.97MB
[WARNING]: Empty continuation line found in:
    RUN     apt-get update &&     apt-get install -y curl gnupg2 dirmngr &&     curl "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - &&     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list &&     apt-get update &&     apt-get -y install google-chrome-stable xvfb unzip &&     curl $TF_TARBALL -o terraform.zip &&     curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     curl $CHROMEDRIVER_TARBALL -o chromedriver.zip &&     unzip chromedriver.zip &&     mv chromedriver /usr/bin &&     chmod +x /usr/bin/chromedriver /usr/bin/terraform &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
[WARNING]: Empty continuation lines will become errors in a future release.
Step 1/15 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/15 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> a68f43939db6
Step 3/15 : ARG CHROMEDRIVER_VERSION
 ---> Using cache
 ---> 290dd212a564
Step 4/15 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 411315268185
Step 5/15 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 4a5610619409
Step 6/15 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 54fcc1f97d9f
Step 7/15 : ENV CHROMEDRIVER_TARBALL http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
 ---> Using cache
 ---> 8157d71fa000
Step 8/15 : RUN     apt-get update &&     apt-get install -y curl gnupg2 dirmngr &&     curl "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - &&     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list &&     apt-get update &&     apt-get -y install google-chrome-stable xvfb unzip &&     curl $TF_TARBALL -o terraform.zip &&     curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     curl $CHROMEDRIVER_TARBALL -o chromedriver.zip &&     unzip chromedriver.zip &&     mv chromedriver /usr/bin &&     chmod +x /usr/bin/chromedriver /usr/bin/terraform &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> a9cc813338a0
Step 9/15 : RUN adduser chromedriver --uid=995 --disabled-password --system
 ---> Using cache
 ---> 0f42736c729b
Step 10/15 : RUN mkdir -p /robotest
 ---> Using cache
 ---> ece2134da126
Step 11/15 : WORKDIR /robotest
 ---> Using cache
 ---> 82182d683de4
Step 12/15 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> 4757d8be13bb
Step 13/15 : COPY build/robotest-e2e /usr/bin/robotest-e2e
 ---> Using cache
 ---> e16806dcf15c
Step 14/15 : RUN chmod +x /usr/bin/robotest-e2e &&     chmod +x /entrypoint.sh
 ---> Using cache
 ---> 519b5d2c8924
Step 15/15 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> 74edf1ba935c
[Warning] One or more build-args [TERRAFORM_PROVIDER_RANDOM_VERSION TERRAFORM_PROVIDER_TEMPLATE_VERSION GRAVITY_VERSION TERRAFORM_PROVIDER_AZURERM_VERSION TERRAFORM_PROVIDER_GOOGLE_VERSION] were not consumed
Successfully built 74edf1ba935c
Successfully tagged quay.io/gravitational/robotest-e2e:testing
rm -rf "/tmp/tmp.zBJaAeB5lU"
Built quay.io/gravitational/robotest-e2e:testing
if [ -z ""/tmp/tmp.Jd2mKNtHhq"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.Jd2mKNtHhq"/build
cp -r ../assets/terraform "/tmp/tmp.Jd2mKNtHhq"
cp -a ../build/robotest-suite "/tmp/tmp.Jd2mKNtHhq"/build/
cp -r suite/* "/tmp/tmp.Jd2mKNtHhq"/
if [ "suite" = "e2e" ]; then \
  cd "/tmp/tmp.Jd2mKNtHhq" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-suite:testing . ; \
else \
  cd "/tmp/tmp.Jd2mKNtHhq" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-suite:testing . ; \
fi
Sending build context to Docker daemon  30.25MB
[WARNING]: Empty continuation line found in:
    RUN curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
[WARNING]: Empty continuation lines will become errors in a future release.
Step 1/19 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/19 : RUN apt-get update &&     apt-get install -y curl unzip gnupg2 dirmngr
 ---> Using cache
 ---> 3edd15c2c2a6
Step 3/19 : ARG GRAVITY_VERSION
 ---> Using cache
 ---> a1aade96486e
Step 4/19 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> 851176a07b81
Step 5/19 : ARG TERRAFORM_PROVIDER_AZURERM_VERSION
 ---> Using cache
 ---> 1fbb0986022b
Step 6/19 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 517fea7a8874
Step 7/19 : ARG TERRAFORM_PROVIDER_GOOGLE_VERSION
 ---> Using cache
 ---> 76e3be98f0f7
Step 8/19 : ARG TERRAFORM_PROVIDER_TEMPLATE_VERSION
 ---> Using cache
 ---> ed91803ffc7d
Step 9/19 : ARG TERRAFORM_PROVIDER_RANDOM_VERSION
 ---> Using cache
 ---> 093340ce8d62
Step 10/19 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> d389ae753332
Step 11/19 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-azurerm/${TERRAFORM_PROVIDER_AZURERM_VERSION}/terraform-provider-azurerm_${TERRAFORM_PROVIDER_AZURERM_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-google/${TERRAFORM_PROVIDER_GOOGLE_VERSION}/terraform-provider-google_${TERRAFORM_PROVIDER_GOOGLE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_PROVIDER_TEMPLATE_VERSION}/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-random/${TERRAFORM_PROVIDER_RANDOM_VERSION}/terraform-provider-random_${TERRAFORM_PROVIDER_RANDOM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 5374b773c7d0
Step 12/19 : RUN curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> c30b6055ee61
Step 13/19 : RUN (curl https://get.gravitational.io/telekube/install/${GRAVITY_VERSION} | bash)
 ---> Using cache
 ---> 2ef939b76bfb
Step 14/19 : RUN mkdir /robotest
 ---> Using cache
 ---> 1a7c44b38a14
Step 15/19 : WORKDIR /robotest
 ---> Using cache
 ---> 89d1f40db631
Step 16/19 : COPY build/robotest-suite /usr/bin/robotest-suite
 ---> Using cache
 ---> d8ca0e260c24
Step 17/19 : COPY terraform /robotest/terraform
 ---> Using cache
 ---> 2d605b3e6473
Step 18/19 : COPY run_suite.sh /usr/bin/run_suite.sh
 ---> 31aa03da936c
Step 19/19 : RUN chmod +x /usr/bin/robotest-suite
 ---> Running in c10099ac8082
Removing intermediate container c10099ac8082
 ---> 1ddd0417c6ca
Successfully built 1ddd0417c6ca
Successfully tagged quay.io/gravitational/robotest-suite:testing
rm -rf "/tmp/tmp.Jd2mKNtHhq"
Built quay.io/gravitational/robotest-suite:testing
make: Leaving directory '/home/walt/git/robotest/docker'
walt@work:~/git/robotest$
</pre>
</details>

After:
<details><summary><code>make -C docker e2e suite VERSION=testing</code></summary>
<pre>
walt@work:~/git/robotest$ make -C docker e2e suite VERSION=testing
make: Entering directory '/home/walt/git/robotest/docker'
if [ -z ""/tmp/tmp.ngfnQhZhcA"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.ngfnQhZhcA"/build
cp -r ../assets/terraform "/tmp/tmp.ngfnQhZhcA"
cp -a ../build/robotest-e2e "/tmp/tmp.ngfnQhZhcA"/build/
cp -r e2e/* "/tmp/tmp.ngfnQhZhcA"/
if [ "e2e" = "e2e" ]; then \
  cd "/tmp/tmp.ngfnQhZhcA" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-e2e:testing . ; \
else \
  cd "/tmp/tmp.ngfnQhZhcA" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-e2e:testing . ; \
fi
Sending build context to Docker daemon  17.97MB
Step 1/15 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/15 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> a68f43939db6
Step 3/15 : ARG CHROMEDRIVER_VERSION
 ---> Using cache
 ---> 290dd212a564
Step 4/15 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 411315268185
Step 5/15 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 4a5610619409
Step 6/15 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 54fcc1f97d9f
Step 7/15 : ENV CHROMEDRIVER_TARBALL http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
 ---> Using cache
 ---> 8157d71fa000
Step 8/15 : RUN     apt-get update &&     apt-get install -y curl gnupg2 dirmngr &&     curl "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - &&     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list &&     apt-get update &&     apt-get -y install google-chrome-stable xvfb unzip &&         curl $TF_TARBALL -o terraform.zip &&     curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&         for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&         curl $CHROMEDRIVER_TARBALL -o chromedriver.zip &&     unzip chromedriver.zip &&     mv chromedriver /usr/bin &&     chmod +x /usr/bin/chromedriver /usr/bin/terraform &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> 4144d0b8a5b7
Step 9/15 : RUN adduser chromedriver --uid=995 --disabled-password --system
 ---> Using cache
 ---> c12ee98b6fbc
Step 10/15 : RUN mkdir -p /robotest
 ---> Using cache
 ---> ebb3451b2cc5
Step 11/15 : WORKDIR /robotest
 ---> Using cache
 ---> c65e640626b1
Step 12/15 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> a73bf8dd1e7c
Step 13/15 : COPY build/robotest-e2e /usr/bin/robotest-e2e
 ---> Using cache
 ---> e1eb65f831ba
Step 14/15 : RUN chmod +x /usr/bin/robotest-e2e &&     chmod +x /entrypoint.sh
 ---> Using cache
 ---> ddd6480c9a0b
Step 15/15 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> 173abae387e7
[Warning] One or more build-args [GRAVITY_VERSION TERRAFORM_PROVIDER_AZURERM_VERSION TERRAFORM_PROVIDER_GOOGLE_VERSION TERRAFORM_PROVIDER_RANDOM_VERSION TERRAFORM_PROVIDER_TEMPLATE_VERSION] were not consumed
Successfully built 173abae387e7
Successfully tagged quay.io/gravitational/robotest-e2e:testing
rm -rf "/tmp/tmp.ngfnQhZhcA"
Built quay.io/gravitational/robotest-e2e:testing
if [ -z ""/tmp/tmp.KwcLQ30Xh6"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.KwcLQ30Xh6"/build
cp -r ../assets/terraform "/tmp/tmp.KwcLQ30Xh6"
cp -a ../build/robotest-suite "/tmp/tmp.KwcLQ30Xh6"/build/
cp -r suite/* "/tmp/tmp.KwcLQ30Xh6"/
if [ "suite" = "e2e" ]; then \
  cd "/tmp/tmp.KwcLQ30Xh6" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-suite:testing . ; \
else \
  cd "/tmp/tmp.KwcLQ30Xh6" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-suite:testing . ; \
fi
Sending build context to Docker daemon  30.25MB
Step 1/19 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/19 : RUN apt-get update &&     apt-get install -y curl unzip gnupg2 dirmngr
 ---> Using cache
 ---> 3edd15c2c2a6
Step 3/19 : ARG GRAVITY_VERSION
 ---> Using cache
 ---> a1aade96486e
Step 4/19 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> 851176a07b81
Step 5/19 : ARG TERRAFORM_PROVIDER_AZURERM_VERSION
 ---> Using cache
 ---> 1fbb0986022b
Step 6/19 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 517fea7a8874
Step 7/19 : ARG TERRAFORM_PROVIDER_GOOGLE_VERSION
 ---> Using cache
 ---> 76e3be98f0f7
Step 8/19 : ARG TERRAFORM_PROVIDER_TEMPLATE_VERSION
 ---> Using cache
 ---> ed91803ffc7d
Step 9/19 : ARG TERRAFORM_PROVIDER_RANDOM_VERSION
 ---> Using cache
 ---> 093340ce8d62
Step 10/19 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> d389ae753332
Step 11/19 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-azurerm/${TERRAFORM_PROVIDER_AZURERM_VERSION}/terraform-provider-azurerm_${TERRAFORM_PROVIDER_AZURERM_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-google/${TERRAFORM_PROVIDER_GOOGLE_VERSION}/terraform-provider-google_${TERRAFORM_PROVIDER_GOOGLE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_PROVIDER_TEMPLATE_VERSION}/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-random/${TERRAFORM_PROVIDER_RANDOM_VERSION}/terraform-provider-random_${TERRAFORM_PROVIDER_RANDOM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 5374b773c7d0
Step 12/19 : RUN curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&         for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&         apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> 5d329e745ea7
Step 13/19 : RUN (curl https://get.gravitational.io/telekube/install/${GRAVITY_VERSION} | bash)
 ---> Using cache
 ---> 4988b148c77f
Step 14/19 : RUN mkdir /robotest
 ---> Using cache
 ---> 98d30e8667ab
Step 15/19 : WORKDIR /robotest
 ---> Using cache
 ---> 57f2cc9edfb6
Step 16/19 : COPY build/robotest-suite /usr/bin/robotest-suite
 ---> Using cache
 ---> a1cca0511a34
Step 17/19 : COPY terraform /robotest/terraform
 ---> Using cache
 ---> 3134e5697668
Step 18/19 : COPY run_suite.sh /usr/bin/run_suite.sh
 ---> 293d7991a023
Step 19/19 : RUN chmod +x /usr/bin/robotest-suite
 ---> Running in 3e6086d63597
Removing intermediate container 3e6086d63597
 ---> 533d196d482a
Successfully built 533d196d482a
Successfully tagged quay.io/gravitational/robotest-suite:testing
rm -rf "/tmp/tmp.KwcLQ30Xh6"
Built quay.io/gravitational/robotest-suite:testing
make: Leaving directory '/home/walt/git/robotest/docker'
</pre>
</details>