### PR TITLE
Add '-retries' cli flag.

### DIFF
--- a/docker/suite/run_suite.sh
+++ b/docker/suite/run_suite.sh
@@ -16,6 +16,7 @@ if [ -d $(dirname ${GRAVITY_URL}) ]; then
 fi
 
 REPEAT_TESTS=${REPEAT_TESTS:-1}
+RETRIES=${RETRIES:-3}
 PARALLEL_TESTS=${PARALLEL_TESTS:-1}
 FAIL_FAST=${FAIL_FAST:-false}
 ALWAYS_COLLECT_LOGS=${ALWAYS_COLLECT_LOGS:-true}
@@ -155,7 +156,7 @@ exec docker run ${DOCKER_RUN_FLAGS} \
 	quay.io/gravitational/robotest-suite:${ROBOTEST_VERSION} \
 	dumb-init robotest-suite -test.timeout=48h ${LOG_CONSOLE} \
 	${GCL_PROJECT_ID:+"-gcl-project-id=${GCL_PROJECT_ID}"} \
-	-test.parallel=${PARALLEL_TESTS} -repeat=${REPEAT_TESTS} -fail-fast=${FAIL_FAST} \
+	-test.parallel=${PARALLEL_TESTS} -repeat=${REPEAT_TESTS} -retries=${RETRIES} -fail-fast=${FAIL_FAST} \
 	-provision="${CLOUD_CONFIG}" -always-collect-logs=${ALWAYS_COLLECT_LOGS} \
 	-resourcegroup-file=/robotest/state/alloc.txt \
 	-destroy-on-success=${DESTROY_ON_SUCCESS} -destroy-on-failure=${DESTROY_ON_FAILURE} \


### PR DESCRIPTION
While debugging, I frequently want to run a test once, with no option
for robotest to re-attempt it if/when it fails.  When robotest auto
retries, I must then abort the program and clean up the resources from
the next attempt. Previously, to do this I needed to edit
lib/defaults/defaults.go.

### Comments
I explored an alternative implementation where `"attempts":3"` was an optional test parameter, e.g.:
```
'install={"attempts":3,"nodes":1,"flavor":"one","os":"redhat:7","storage_driver":"overlay2","role":"node"}'
```
I liked that this allowed per test retry configuration, but the impmentation had a couple downsides:

1) it was considerably more invasive
2) it raised difficult questions about configuration hierarchy.  Specifically of the above keys:

* attempts

is configuration outside the test

* nodes
* os

are largely provisioner config values

* flavor
* storage_driver
* role

are Gravity install options (aka test parameters) but could probably be defaulted or derived from above keys.  When I started considering the correct way to structure this data, it lead me down more substantial config refactoring that is well outside of the scope of what I set out to accomplish.  Thus I decided to keep it simple.  I can file a follow up ticket if you think refactoring robotest config more holistically is worthwhile.

### Testing Done
Via `docker/suite/run_suite.sh`
<details><summary><code>docker/suite/run_suite.sh</code> wrapper with 1 retry</summary>
<pre>
walt@work:~/git/robotest$ ./cfg/docker.sh
2.0.0-alpha.1.2-2e81e2b5: Pulling from gravitational/robotest-suite
Digest: sha256:f692f4dbc954bdf4f9035adbad65bb6efbe1daf376f19ba8a8208fbf0d0d77b7
Status: Image is up to date for quay.io/gravitational/robotest-suite:2.0.0-alpha.1.2-2e81e2b5
quay.io/gravitational/robotest-suite:2.0.0-alpha.1.2-2e81e2b5
+ exec docker run -v /home/walt/git/robotest/wd_suite/state:/robotest/state -v /home/walt/.ssh/robotest:/robotest/config/ops.pem -v /home/walt/.ssh/robotest.pub:/robotest/config/ops_rsa.pub -v /home/walt/git/robotest/<redacted>.json:/robotest/config/creds.json -v /home/walt/go/bin:/installer/bin -v /tmp/tmp.0M1ybOZOHN:/robotest/config/vars.json -v /home/walt/git/robotest/<redacted>.json:/robotest/config/gcp.json -e GOOGLE_APPLICATION_CREDENTIALS=/robotest/config/gcp.json quay.io/gravitational/robotest-suite:2.0.0-alpha.1.2-2e81e2b5 dumb-init robotest-suite -test.timeout=48h -gcl-project-id=kubeadm-167321 -test.parallel=1 -repeat=1 -retries=3 -fail-fast=false '-provision=
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.5/linux/x86_64/telekube-7.0.5-linux-x86_64.tar
gravity_url: /installer/bin/gravity
script_path: /robotest/terraform/gce
state_dir: /robotest/state
cloud: gce
aws:
  access_key: <redacted>
  secret_key: <redacted>
  ssh_user: ubuntu
  key_path: /robotest/config/ops.pem
  key_pair: ops
  region: us-east-1
  vpc: Create New
  docker_device: /dev/xvdb

gce:
  credentials: /robotest/config/creds.json
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /robotest/config/ops.pem
  ssh_pub_key_path: /robotest/config/ops_rsa.pub
  var_file_path: /robotest/config/vars.json

' -always-collect-logs=true -resourcegroup-file=/robotest/state/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug 'noop={"fail":true,"sleep":3}'
time="2020-05-15T03:49:36Z" level=info msg="[PROFILING] http localhost:6060"
time="2020-05-15T03:49:36Z" level=debug msg="Version:   2.0.0-alpha.1.2+2e81e2b5"
time="2020-05-15T03:49:36Z" level=debug msg="Git Commit:        2e81e2b5e7a618d5ac426db310dd0a87c004680d"
level=info msg=RUNNING commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/cenkalti/backoff/retry.go:36]
level=info msg="timer elapsed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 where=[/suite/sanity/noop.go:49]
level=error msg=FAILED commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=info msg="BQ SAVE" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d data=map[extra:sleep=3 fail=true name:walt-noop-1 status:FAILED suite:ecd47ab5-df7d-432b-ac77-68009f79afdd ts:2020-05-15 03:49:40.154550134 +0000 UTC m=+3.883558005 uuid:5e44de0e-20dd-43bc-b6b5-8ba87af28599] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=error msg="BQ status update failed" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=warning msg="Test "walt-noop-1" completed with error." error="request to cancel" where=[/cenkalti/backoff/retry.go:36]
level=warning msg="Retrying "walt-noop-1-T2" (1/3)." where=[/cenkalti/backoff/retry.go:36]
level=info msg=RUNNING commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/cenkalti/backoff/retry.go:36]
level=info msg="timer elapsed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 where=[/suite/sanity/noop.go:49]
level=error msg=FAILED commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=info msg="BQ SAVE" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d data=map[extra:sleep=3 fail=true name:walt-noop-1-T2 status:FAILED suite:ecd47ab5-df7d-432b-ac77-68009f79afdd ts:2020-05-15 03:49:44.101722012 +0000 UTC m=+7.830729891 uuid:05be76e0-7262-46a4-a21a-26ddb55ce063] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=error msg="BQ status update failed" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=warning msg="Test "walt-noop-1-T2" completed with error." error="request to cancel" where=[/cenkalti/backoff/retry.go:36]
level=warning msg="Retrying "walt-noop-1-T3" (2/3)." where=[/cenkalti/backoff/retry.go:36]
level=info msg=RUNNING commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/cenkalti/backoff/retry.go:36]
level=info msg="timer elapsed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 where=[/suite/sanity/noop.go:49]
level=error msg=FAILED commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=info msg="BQ SAVE" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d data=map[extra:sleep=3 fail=true name:walt-noop-1-T3 status:FAILED suite:ecd47ab5-df7d-432b-ac77-68009f79afdd ts:2020-05-15 03:49:47.734433761 +0000 UTC m=+11.463441577 uuid:d10ff826-c128-46ff-8eab-aa5b2eb42b71] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=error msg="BQ status update failed" commit=2e81e2b5e7a618d5ac426db310dd0a87c004680d error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.2+2e81e2b5" where=[/src/runtime/panic.go:522]
level=warning msg="Test "walt-noop-1-T3" completed with error." error="request to cancel" where=[/cenkalti/backoff/retry.go:36]
time="2020-05-15T03:49:47Z" level=warning msg="All attempts failed." error="request to cancel"

******** TEST SUITE COMPLETED **********
FAILED walt-noop-1 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225e44de0e-20dd-43bc-b6b5-8ba87af28599%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T2 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2205be76e0-7262-46a4-a21a-26ddb55ce063%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T3 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22d10ff826-c128-46ff-8eab-aa5b2eb42b71%22%0Alabels.__suite__%3D%22ecd47ab5-df7d-432b-ac77-68009f79afdd%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
--- FAIL: TestMain (12.01s)
    --- FAIL: TestMain/run (0.00s)
        --- FAIL: TestMain/run/walt-noop-1 (10.67s)
            testsuite.go:326: request to cancel
</pre>
</details>

<details><summary>non-dockerized noop with 5 retries</summary>
<pre>
walt@work:~/git/robotest$ ./cfg/noop.sh
make: Nothing to be done for 'version'.
/home/walt/git/robotest
+ dlv test ./suite -- -test.timeout=1m -gcl-project-id=<redacted> -retries=5 -tag=walt -suite=sanity -debug '-provision=
installer_url: na
gravity_url: na
script_path: na
tf_plugin_dir: na
state_dir: /home/walt/git/robotest/logs/0514-1712
cloud: gce
gce:
  credentials: na
  vm_type: na
  region: na
  ssh_key_path: na
  ssh_pub_key_path: na
  var_file_path: na
' 'noop={"fail":true,"sleep":3}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060
DEBU[0000] Version:     2.0.0-alpha.1.1+9ccc9fe5
DEBU[0000] Git Commit:  9ccc9fe51c877a88d2c46c401f15afa2747daf8c
INFO RUNNING                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/retry.go:36]
INFO timer elapsed                                 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 where=[/suite/sanity/noop.go:49]
ERRO FAILED                                        commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
INFO BQ SAVE                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c data=map[extra:sleep=3 fail=true name:walt-noop-1 status:FAILED suite:a3fc7143-270a-4724-977e-c2cee2fcfe08 ts:2020-05-14 17:12:50.976073778 -0700 PDT m=+3.807308271 uuid:7c88261b-9e5c-4bdf-b5e7-410361ad2cb4] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
ERRO BQ status update failed                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
WARN Test "walt-noop-1" completed with error.      error="request to cancel" where=[/retry.go:36]
WARN Retrying "walt-noop-1-T2" (1/5).              where=[/retry.go:36]
INFO RUNNING                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/retry.go:36]
INFO timer elapsed                                 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 where=[/suite/sanity/noop.go:49]
ERRO FAILED                                        commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
INFO BQ SAVE                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c data=map[extra:sleep=3 fail=true name:walt-noop-1-T2 status:FAILED suite:a3fc7143-270a-4724-977e-c2cee2fcfe08 ts:2020-05-14 17:12:54.766064075 -0700 PDT m=+7.597298566 uuid:391d9b25-bcaf-409b-9042-506b49d9ac23] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
ERRO BQ status update failed                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T2 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
WARN Test "walt-noop-1-T2" completed with error.   error="request to cancel" where=[/retry.go:36]
WARN Retrying "walt-noop-1-T3" (2/5).              where=[/retry.go:36]
INFO RUNNING                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/retry.go:36]
INFO timer elapsed                                 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 where=[/suite/sanity/noop.go:49]
ERRO FAILED                                        commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
INFO BQ SAVE                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c data=map[extra:sleep=3 fail=true name:walt-noop-1-T3 status:FAILED suite:a3fc7143-270a-4724-977e-c2cee2fcfe08 ts:2020-05-14 17:12:58.571972053 -0700 PDT m=+11.403206541 uuid:f466ea04-832d-45a4-9b69-796a90dcea2f] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
ERRO BQ status update failed                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T3 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
WARN Test "walt-noop-1-T3" completed with error.   error="request to cancel" where=[/retry.go:36]
WARN Retrying "walt-noop-1-T4" (3/5).              where=[/retry.go:36]
INFO RUNNING                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T4 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/retry.go:36]
INFO timer elapsed                                 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T4 where=[/suite/sanity/noop.go:49]
ERRO FAILED                                        commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T4 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
INFO BQ SAVE                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c data=map[extra:sleep=3 fail=true name:walt-noop-1-T4 status:FAILED suite:a3fc7143-270a-4724-977e-c2cee2fcfe08 ts:2020-05-14 17:13:02.710288122 -0700 PDT m=+15.541522620 uuid:0c82e8e2-e5d6-4800-90ff-3df4f4e31c30] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T4 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
ERRO BQ status update failed                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T4 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
WARN Test "walt-noop-1-T4" completed with error.   error="request to cancel" where=[/retry.go:36]
WARN Retrying "walt-noop-1-T5" (4/5).              where=[/retry.go:36]
INFO RUNNING                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T5 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/retry.go:36]
INFO timer elapsed                                 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T5 where=[/suite/sanity/noop.go:49]
ERRO FAILED                                        commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T5 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
INFO BQ SAVE                                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c data=map[extra:sleep=3 fail=true name:walt-noop-1-T5 status:FAILED suite:a3fc7143-270a-4724-977e-c2cee2fcfe08 ts:2020-05-14 17:13:07.807533106 -0700 PDT m=+20.638767640 uuid:e0ebf831-3a64-4aef-b7fa-230c125bc7d9] logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T5 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
ERRO BQ status update failed                       commit=9ccc9fe51c877a88d2c46c401f15afa2747daf8c error="1 row insertion failed" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-noop-1-T5 param="{"sleep":3,"fail":true}" version="2.0.0-alpha.1.1+9ccc9fe5" where=[/suite/sanity/noop.go:52]
WARN Test "walt-noop-1-T5" completed with error.   error="request to cancel" where=[/retry.go:36]
WARN[0020] All attempts failed.                          error="request to cancel"

******** TEST SUITE COMPLETED **********
FAILED walt-noop-1 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227c88261b-9e5c-4bdf-b5e7-410361ad2cb4%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T2 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22391d9b25-bcaf-409b-9042-506b49d9ac23%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T3 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22f466ea04-832d-45a4-9b69-796a90dcea2f%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T4 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220c82e8e2-e5d6-4800-90ff-3df4f4e31c30%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
FAILED walt-noop-1-T5 {"sleep":3,"fail":true} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e0ebf831-3a64-4aef-b7fa-230c125bc7d9%22%0Alabels.__suite__%3D%22a3fc7143-270a-4724-977e-c2cee2fcfe08%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
--- FAIL: TestMain (20.99s)
    --- FAIL: TestMain/run (0.00s)
        --- FAIL: TestMain/run/walt-noop-1 (19.93s)
            testsuite.go:326: request to cancel
FAIL
Process 247268 has exited with status 1
(dlv) exit
</pre>
</details>