### PR TITLE
Consistently add flags to recursive make targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ TARGETS := e2e suite
 VERSION ?= $(shell ./version.sh)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 VERSIONFILE := version.go
-# docker doesn't allow "+" in image tags: https://github.com/docker/distribution/issues/1201
-DOCKER_VERSION ?= $(subst +,-,$(VERSION))
 NOROOT := -u $$(id -u):$$(id -g)
 SRCDIR := /go/src/github.com/gravitational/robotest
 BUILDDIR ?= $(abspath build)
+# docker doesn't allow "+" in image tags: https://github.com/docker/distribution/issues/1201
+export DOCKER_VERSION ?= $(subst +,-,$(VERSION))
+export DOCKER_TAG ?=
+export DOCKER_ARGS ?= --pull
 DOCKERFLAGS := --rm=true $(NOROOT) -v $(PWD):$(SRCDIR) -v $(BUILDDIR):$(SRCDIR)/build -w $(SRCDIR)
 BUILDBOX := robotest:buildbox
-DOCKER_ARGS ?= --pull
 GOLANGCI_LINT_VER ?= 1.21.0
 
 .PHONY: help
@@ -46,12 +47,12 @@ buildbox:
 .PHONY: containers
 containers: ## Build container images.
 containers: build lint
-	$(MAKE) -C docker containers DOCKER_ARGS=$(DOCKER_ARGS)
+	$(MAKE) -C docker containers
 
 .PHONY: publish
 publish: ## Publish container images to quay.io.
 publish: build lint
-	$(MAKE) -C docker -j publish VERSION=$(DOCKER_VERSION) TAG=$(TAG)
+	$(MAKE) -C docker -j publish
 
 .PHONY: clean
 clean: ## Remove intermediate build artifacts & cache.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,9 @@
 TARGETS := e2e suite
 DOCKER_REPO := quay.io/gravitational
+# An empty version will result in build failure, call targets from the top level Makefile to set this
+DOCKER_VERSION ?=
+# An empty tag will be ignored
+DOCKER_TAG ?=
 DOCKER_ARGS ?= --pull
 
 GRAVITY_VERSION := 5.5.20
@@ -35,7 +39,7 @@ $(BINARIES):
 .PHONY: $(TARGETS)
 $(TARGETS): $(BINARIES)
 	$(eval TEMPDIR = "$(shell mktemp -d)")
-	$(eval IMAGE = $(DOCKER_REPO)/robotest-$@:$(VERSION))
+	$(eval IMAGE = $(DOCKER_REPO)/robotest-$@:$(DOCKER_VERSION))
 	if [ -z "$(TEMPDIR)" ]; then \
 	  echo "TEMPDIR is not set"; exit 1; \
 	fi;
@@ -64,10 +68,10 @@ publish: $(DOCKER_REPO)/robotest-suite
 
 .PHONY: $(DOCKER_IMG)
 $(DOCKER_IMG): $(TARGETS)
-	docker push $@:$(VERSION)
-ifneq ($(TAG),)
-	docker tag $@:$(VERSION) $@:$(TAG)
-	docker push $@:$(TAG)
+	docker push $@:$(DOCKER_VERSION)
+ifneq ($(DOCKER_TAG),)
+	docker tag $@:$(DOCKER_VERSION) $@:$(DOCKER_TAG)
+	docker push $@:$(DOCKER_TAG)
 endif
 
 


### PR DESCRIPTION
Without this `publish` was failing to pull, and `containers` was failing to
pass along the version and tag information.

### Testing Done

After:
<details><summary>make containers</summary>
<pre>
walt@work:~/git/robotest$ make containers
docker build --pull --tag robotest:buildbox \
        --build-arg UID=$(id -u) \
        --build-arg GID=$(id -g) \
        --build-arg GOLANGCI_LINT_VER=1.21.0 \
        docker/build
Sending build context to Docker daemon  3.072kB
Step 1/12 : FROM quay.io/gravitational/debian-venti:go1.12.9-stretch
go1.12.9-stretch: Pulling from gravitational/debian-venti
Digest: sha256:0fea800bbea53134644b9d4a52bdcec433cbcb7ab3a8530279c0e4373b3a5cb4
Status: Image is up to date for quay.io/gravitational/debian-venti:go1.12.9-stretch
 ---> 273a8ecbe1d9
Step 2/12 : ARG UID
 ---> Using cache
 ---> 85e54c5ce85a
Step 3/12 : ARG GID
 ---> Using cache
 ---> a1b115778ea5
Step 4/12 : ARG GOLANGCI_LINT_VER
 ---> Using cache
 ---> c2fd3255d861
Step 5/12 : ENV GOPACKAGESPRINTGOLISTERRORS=true
 ---> Using cache
 ---> d8dec008d4df
Step 6/12 : RUN groupadd builder --gid=$GID -o;     useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash;
 ---> Using cache
 ---> ee12c5143006
Step 7/12 : RUN (mkdir -p /go/src/github.com/gravitational/robotest && chown -R builder /go ${GOPATH})
 ---> Using cache
 ---> 0233df898099
Step 8/12 : RUN (mkdir -p /go/bin)
 ---> Using cache
 ---> eed780091f7c
Step 9/12 : ENV LANGUAGE="en_US.UTF-8"     LANG="en_US.UTF-8"     LC_ALL="en_US.UTF-8"     LC_CTYPE="en_US.UTF-8"     GOPATH="/gopath"     PATH="$PATH:/opt/go/bin:/go/bin"
 ---> Using cache
 ---> cedf7762ef25
Step 10/12 : RUN (wget -q https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VER/golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz &&        tar -xvf golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz -C /go/bin               golangci-lint-$GOLANGCI_LINT_VER-linux-amd64/golangci-lint --strip-components=1 &&      rm golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz)
 ---> Using cache
 ---> 547c9511a2c0
Step 11/12 : WORKDIR /gopath/src/github.com/gravitational/robotest
 ---> Using cache
 ---> 53352ea1e3a6
Step 12/12 : VOLUME ["/gopath/src/github.com/gravitational/robotest"]
 ---> Using cache
 ---> 5b033969e4f6
Successfully built 5b033969e4f6
Successfully tagged robotest:buildbox
mkdir -p build
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest robotest:buildbox \
        dumb-init make -j e2e suite
version metadata saved to version.go
go version go1.12.9 linux/amd64
go version go1.12.9 linux/amd64
cd /go/src/github.com/gravitational/robotest && \
        GO111MODULE=on go test -mod=vendor -c -i ./e2e -o build/robotest-e2e
cd /go/src/github.com/gravitational/robotest && \
        GO111MODULE=on go test -mod=vendor -c -i ./suite -o build/robotest-suite
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest \
        --env="GO111MODULE=off" \
        robotest:buildbox dumb-init golangci-lint run \
        --skip-dirs=vendor \
        --timeout=2m

make -C docker containers DOCKER_ARGS=--pull VERSION=2.0.0-alpha.1.4-7bcbe637 TAG=
make[1]: Entering directory '/home/walt/git/robotest/docker'
if [ -z ""/tmp/tmp.DmnhRHzlov"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.DmnhRHzlov"/build
cp -r ../assets/terraform "/tmp/tmp.DmnhRHzlov"
cp -a ../build/robotest-e2e "/tmp/tmp.DmnhRHzlov"/build/
cp -r e2e/* "/tmp/tmp.DmnhRHzlov"/
if [ "e2e" = "e2e" ]; then \
  cd "/tmp/tmp.DmnhRHzlov" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-e2e:2.0.0-alpha.1.4-7bcbe637 . ; \
else \
  cd "/tmp/tmp.DmnhRHzlov" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-e2e:2.0.0-alpha.1.4-7bcbe637 . ; \
fi
Sending build context to Docker daemon  17.97MB
[WARNING]: Empty continuation line found in:
    RUN     apt-get update &&     apt-get install -y curl gnupg2 dirmngr &&     curl "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - &&     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list &&     apt-get update &&     apt-get -y install google-chrome-stable xvfb unzip &&     curl $TF_TARBALL -o terraform.zip &&     curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     curl $CHROMEDRIVER_TARBALL -o chromedriver.zip &&     unzip chromedriver.zip &&     mv chromedriver /usr/bin &&     chmod +x /usr/bin/chromedriver /usr/bin/terraform &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
[WARNING]: Empty continuation lines will become errors in a future release.
Step 1/15 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/15 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> a68f43939db6
Step 3/15 : ARG CHROMEDRIVER_VERSION
 ---> Using cache
 ---> 290dd212a564
Step 4/15 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 411315268185
Step 5/15 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 4a5610619409
Step 6/15 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 54fcc1f97d9f
Step 7/15 : ENV CHROMEDRIVER_TARBALL http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip
 ---> Using cache
 ---> 8157d71fa000
Step 8/15 : RUN     apt-get update &&     apt-get install -y curl gnupg2 dirmngr &&     curl "https://dl-ssl.google.com/linux/linux_signing_key.pub" | apt-key add - &&     echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list &&     apt-get update &&     apt-get -y install google-chrome-stable xvfb unzip &&     curl $TF_TARBALL -o terraform.zip &&     curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     curl $CHROMEDRIVER_TARBALL -o chromedriver.zip &&     unzip chromedriver.zip &&     mv chromedriver /usr/bin &&     chmod +x /usr/bin/chromedriver /usr/bin/terraform &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> a9cc813338a0
Step 9/15 : RUN adduser chromedriver --uid=995 --disabled-password --system
 ---> Using cache
 ---> 0f42736c729b
Step 10/15 : RUN mkdir -p /robotest
 ---> Using cache
 ---> ece2134da126
Step 11/15 : WORKDIR /robotest
 ---> Using cache
 ---> 82182d683de4
Step 12/15 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> 4757d8be13bb
Step 13/15 : COPY build/robotest-e2e /usr/bin/robotest-e2e
 ---> Using cache
 ---> e16806dcf15c
Step 14/15 : RUN chmod +x /usr/bin/robotest-e2e &&     chmod +x /entrypoint.sh
 ---> Using cache
 ---> 519b5d2c8924
Step 15/15 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> 74edf1ba935c
[Warning] One or more build-args [GRAVITY_VERSION TERRAFORM_PROVIDER_AZURERM_VERSION TERRAFORM_PROVIDER_GOOGLE_VERSION TERRAFORM_PROVIDER_RANDOM_VERSION TERRAFORM_PROVIDER_TEMPLATE_VERSION] were not consumed
Successfully built 74edf1ba935c
Successfully tagged quay.io/gravitational/robotest-e2e:2.0.0-alpha.1.4-7bcbe637
rm -rf "/tmp/tmp.DmnhRHzlov"
Built quay.io/gravitational/robotest-e2e:2.0.0-alpha.1.4-7bcbe637
if [ -z ""/tmp/tmp.xiVeANVLwR"" ]; then \
  echo "TEMPDIR is not set"; exit 1; \
fi;
mkdir -p "/tmp/tmp.xiVeANVLwR"/build
cp -r ../assets/terraform "/tmp/tmp.xiVeANVLwR"
cp -a ../build/robotest-suite "/tmp/tmp.xiVeANVLwR"/build/
cp -r suite/* "/tmp/tmp.xiVeANVLwR"/
if [ "suite" = "e2e" ]; then \
  cd "/tmp/tmp.xiVeANVLwR" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --build-arg CHROMEDRIVER_VERSION=2.39 --rm=true --pull -t quay.io/gravitational/robotest-suite:2.0.0-alpha.1.4-7bcbe637 . ; \
else \
  cd "/tmp/tmp.xiVeANVLwR" && docker build --build-arg TERRAFORM_VERSION=0.12.9 --build-arg GRAVITY_VERSION=5.5.20 --build-arg TERRAFORM_PROVIDER_AZURERM_VERSION=$TERRAFORM_PROVIDER_AZURERM_VERSION --build-arg TERRAFORM_PROVIDER_AWS_VERSION=$TERRAFORM_PROVIDER_AWS_VERSION --build-arg TERRAFORM_PROVIDER_GOOGLE_VERSION=$TERRAFORM_PROVIDER_GOOGLE_VERSION --build-arg TERRAFORM_PROVIDER_RANDOM_VERSION=$TERRAFORM_PROVIDER_RANDOM_VERSION --build-arg TERRAFORM_PROVIDER_TEMPLATE_VERSION=$TERRAFORM_PROVIDER_TEMPLATE_VERSION --rm=true --pull -t quay.io/gravitational/robotest-suite:2.0.0-alpha.1.4-7bcbe637 . ; \
fi
Sending build context to Docker daemon  30.24MB
[WARNING]: Empty continuation line found in:
    RUN curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
[WARNING]: Empty continuation lines will become errors in a future release.
Step 1/19 : FROM quay.io/gravitational/debian-grande:stretch
stretch: Pulling from gravitational/debian-grande
Digest: sha256:473d5b85dbf43740333e15a3eb9111fa9949a560a28938b9b3d838ba893e2f39
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> 42495e4aa985
Step 2/19 : RUN apt-get update &&     apt-get install -y curl unzip gnupg2 dirmngr
 ---> Using cache
 ---> 3edd15c2c2a6
Step 3/19 : ARG GRAVITY_VERSION
 ---> Using cache
 ---> a1aade96486e
Step 4/19 : ARG TERRAFORM_VERSION
 ---> Using cache
 ---> 851176a07b81
Step 5/19 : ARG TERRAFORM_PROVIDER_AZURERM_VERSION
 ---> Using cache
 ---> 1fbb0986022b
Step 6/19 : ARG TERRAFORM_PROVIDER_AWS_VERSION
 ---> Using cache
 ---> 517fea7a8874
Step 7/19 : ARG TERRAFORM_PROVIDER_GOOGLE_VERSION
 ---> Using cache
 ---> 76e3be98f0f7
Step 8/19 : ARG TERRAFORM_PROVIDER_TEMPLATE_VERSION
 ---> Using cache
 ---> ed91803ffc7d
Step 9/19 : ARG TERRAFORM_PROVIDER_RANDOM_VERSION
 ---> Using cache
 ---> 093340ce8d62
Step 10/19 : ENV TF_TARBALL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> d389ae753332
Step 11/19 : ENV TF_PLUGINS     https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_PROVIDER_AWS_VERSION}/terraform-provider-aws_${TERRAFORM_PROVIDER_AWS_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-azurerm/${TERRAFORM_PROVIDER_AZURERM_VERSION}/terraform-provider-azurerm_${TERRAFORM_PROVIDER_AZURERM_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-google/${TERRAFORM_PROVIDER_GOOGLE_VERSION}/terraform-provider-google_${TERRAFORM_PROVIDER_GOOGLE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_PROVIDER_TEMPLATE_VERSION}/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip     https://releases.hashicorp.com/terraform-provider-random/${TERRAFORM_PROVIDER_RANDOM_VERSION}/terraform-provider-random_${TERRAFORM_PROVIDER_RANDOM_VERSION}_linux_amd64.zip
 ---> Using cache
 ---> 5374b773c7d0
Step 12/19 : RUN curl ${TF_TARBALL} -o terraform.zip &&     unzip terraform.zip -d /usr/bin &&     rm -f terraform.zip &&     mkdir -p /etc/terraform/plugins &&     for plugin in $TF_PLUGINS; do         curl ${plugin} -o plugin.zip &&         unzip plugin.zip -d /etc/terraform/plugins &&         rm -f plugin.zip;     done &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         /usr/share/{doc,doc-base,man}/         /tmp/*
 ---> Using cache
 ---> c30b6055ee61
Step 13/19 : RUN (curl https://get.gravitational.io/telekube/install/${GRAVITY_VERSION} | bash)
 ---> Using cache
 ---> 2ef939b76bfb
Step 14/19 : RUN mkdir /robotest
 ---> Using cache
 ---> 1a7c44b38a14
Step 15/19 : WORKDIR /robotest
 ---> Using cache
 ---> 89d1f40db631
Step 16/19 : COPY build/robotest-suite /usr/bin/robotest-suite
 ---> e786eff5ba3d
Step 17/19 : COPY terraform /robotest/terraform
 ---> eb13f1e8bf0a
Step 18/19 : COPY run_suite.sh /usr/bin/run_suite.sh
 ---> a3ba5a43df78
Step 19/19 : RUN chmod +x /usr/bin/robotest-suite
 ---> Running in bac81d386aa9
Removing intermediate container bac81d386aa9
 ---> 403877d47fa9
Successfully built 403877d47fa9
Successfully tagged quay.io/gravitational/robotest-suite:2.0.0-alpha.1.4-7bcbe637
rm -rf "/tmp/tmp.xiVeANVLwR"
Built quay.io/gravitational/robotest-suite:2.0.0-alpha.1.4-7bcbe637
make[1]: Leaving directory '/home/walt/git/robotest/docker'
</pre>
</details>