### PR TITLE
Add a shrink test scenario.

### DIFF
--- a/infra/gravity/cluster_resize.go
+++ b/infra/gravity/cluster_resize.go
@@ -3,47 +3,33 @@ package gravity
 import (
 	"context"
 
-	"github.com/gravitational/robotest/lib/constants"
-	"github.com/gravitational/robotest/lib/utils"
-
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 )
 
-func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
-	if len(current) == 0 || len(extra) == 0 {
+// Expand joins one or more node to a cluster
+func (c *TestContext) Expand(currentCluster, nodesToJoin []Gravity, p InstallParam) error {
+	if len(currentCluster) < 1 {
 		return trace.BadParameter("empty node list")
 	}
-	if c.provisionerCfg.CloudProvider == constants.Ops {
-		return trace.NotImplemented("not implemented")
+	if len(nodesToJoin) < 1 { // nothing to be done
+		return nil
 	}
 
-	c.Logger().WithFields(logrus.Fields{
-		"current": current,
-		"extra":   extra,
-	}).Info("Expand.")
-
+	// status is solely used for gathering the join token, can this be replaced
+	// with InstallParam.Token -- 2020-05 walt
+	peer := currentCluster[0]
 	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
-
-	master := current[0]
-	joinAddr := master.Node().PrivateAddr()
-	status, err := master.Status(ctx)
+	status, err := peer.Status(ctx)
 	if err != nil {
-		return trace.Wrap(err, "query status from [%v]", master)
+		return trace.Wrap(err, "Query status from [%v]: %v", peer, err)
 	}
+	token := status.Cluster.Token.Token
 
-	ctx, cancel = context.WithTimeout(c.ctx, withDuration(c.timeouts.Install, len(extra)))
-	defer cancel()
+	c.Logger().WithField("current", currentCluster).WithField("extra", nodesToJoin).Info("Expand.")
 
-	for _, node := range extra {
-		c.Logger().WithField("node", node).Info("Join.")
-		err = node.Join(ctx, JoinCmd{
-			PeerAddr: joinAddr,
-			Token:    status.Cluster.Token.Token,
-			Role:     p.Role,
-			StateDir: p.StateDir,
-		})
+	for _, node := range nodesToJoin {
+		err = c.joinNode(peer, node, token, p)
 		if err != nil {
 			return trace.Wrap(err, "error joining cluster on node %s: %v", node.String(), err)
 		}
@@ -52,38 +38,67 @@ func (c *TestContext) Expand(current, extra []Gravity, p InstallParam) error {
 	return nil
 }
 
-// ShrinkLeave will gracefully leave cluster
-func (c *TestContext) ShrinkLeave(nodesToKeep, nodesToRemove []Gravity) error {
-	ctx, cancel := context.WithTimeout(c.ctx, withDuration(c.timeouts.Leave, len(nodesToRemove)))
+// JoinNode has one node join a peer already in a cluster
+func (c *TestContext) JoinNode(peer, nodeToJoin Gravity, p InstallParam) error {
+
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
 	defer cancel()
-
-	errs := make(chan error, len(nodesToRemove))
-	for _, node := range nodesToRemove {
-		go func(n Gravity) {
-			err := n.Leave(ctx, Graceful(true))
-			errs <- trace.Wrap(err, n.Node().PrivateAddr())
-		}(node)
+	status, err := peer.Status(ctx)
+	if err != nil {
+		return trace.Wrap(err, "Query status from [%v]: %v", peer, err)
 	}
-
-	return trace.Wrap(utils.CollectErrors(ctx, errs))
+	err = c.joinNode(peer, nodeToJoin, status.Cluster.Token.Token, p)
+	return trace.Wrap(err)
 }
 
-// RemoveNode simulates sudden nodes loss within an existing cluster followed by node eviction
-func (c *TestContext) RemoveNode(nodesToKeep []Gravity, remove Gravity) error {
+// joinNode is a helper abstracting logic common to a single node or a multi-node join.
+func (c *TestContext) joinNode(peer, nodeToJoin Gravity, token string, p InstallParam) error {
+
+	cmd := JoinCmd{
+		PeerAddr: peer.Node().PrivateAddr(),
+		Token:    token,
+		Role:     p.Role,
+		StateDir: p.StateDir,
+	}
+
+	c.Logger().WithField("node", nodeToJoin).Info("Join.")
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Install)
+	defer cancel()
+	err := nodeToJoin.Join(ctx, cmd)
+	return trace.Wrap(err)
+
+}
+
+// Shrink evicts one or more nodes from the cluster
+func (c *TestContext) Shrink(nodesToKeep, nodesToRemove []Gravity) error {
 	if len(nodesToKeep) == 0 {
 		return trace.BadParameter("node list empty")
 	}
+	if len(nodesToRemove) > 1 { // nothing to be removed
+		return nil
+	}
 
 	master := nodesToKeep[0]
+	// Gravity does not support multiple removes in parallel, so loop is
+	// intentionally serialized -- 2020-04 walt
+	// see https://github.com/gravitational/robotest/pull/229#discussion_r428221568
+	for _, node := range nodesToRemove {
+		err := c.RemoveNode(master, node)
+		if err == nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// RemoveNode evicts a singe node from the cluster
+func (c *TestContext) RemoveNode(master, nodeToRemove Gravity) error {
+
+	c.Logger().WithField("node", nodeToRemove).WithField("master", master).Info("Remove.")
 
 	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Leave)
 	defer cancel()
 
-	err := master.Remove(ctx, remove.Node().PrivateAddr(), Graceful(!remove.Offline()))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = c.Status(nodesToKeep)
+	err := master.Remove(ctx, nodeToRemove.Node().PrivateAddr(), Graceful(!nodeToRemove.Offline()))
 	return trace.Wrap(err)
 }

--- a/suite/README.md
+++ b/suite/README.md
@@ -92,14 +92,20 @@ Every test is passed as argument to launch script as `testname={json}`. Mind the
 
 `provision` takes same args but will not run any installer, just provision VMs. 
 
-### Install cluster, then resize
+### Install cluster, then expand
 
-`resize` 
+`resize`
 
 Inherits parameters from `install`, plus:
 
 * `to` (uint) number of nodes to expand (or shrink) to
 * `graceful` (bool, default=false) whether to perform graceful or forced node shrink
+
+### Install cluster, expand by one, shrink by one
+
+`shrink`
+
+Inherits all parameters from `install`.
 
 ### Install cluster, then upgrade
 
@@ -107,16 +113,16 @@ Inherits parameters from `install`, plus:
 
 * `upgrade_from` initial installer to use
 
-### Replace cluster nodes
+### Recover cluster nodes
 
-`replace` inherits `install` parameters. 
+`recover` inherits `install` parameters.
 
 * `roles` (array) `["apimaster","clmaster","clbackup","worker"]` will sequentially locate and replace nodes with given role
 * `recycle` (bool) if true, a clean node will be used for each operation replacement, if false then +1 node would be created in addition to `nodes` parameters and will sequentially be replaced as per nodes. Note the `worker` is no-op for cluster with <= 3 nodes.
-* `expand_before_shrink` (bool) expand cluster before node removal or after. 
+* `expand_before_shrink` (bool) expand cluster before node removal or after.
 * `pwroff_before_remove` (bool) if true, then node would be `poweroff -f` before node replacement. Cannot be combined with `recycle=true`
 
-`replace_variety` will generate a combination of `replace` parameterized tests.
+`recoverV` will generate a combination of `recover` parameterized tests.
 
 ### Post installer transfer script
 When a certain application may require extra setup after provisioning and installer transfer is complete, this could be achieved by passing extra parameters to tests: 

--- a/suite/sanity/install.go
+++ b/suite/sanity/install.go
@@ -29,10 +29,16 @@ func (p installParam) Save() (row map[string]bigquery.Value, insertID string, er
 	return row, "", nil
 }
 
-func provisionNodes(g *gravity.TestContext, cfg gravity.ProvisionerConfig, param installParam) (gravity.Cluster, error) {
-	return g.Provision(cfg.WithOS(param.OSFlavor).
+// withInstallParams returns copy of config applying extended tag to it
+func withInstallParam(cfg gravity.ProvisionerConfig, param installParam) gravity.ProvisionerConfig {
+	return cfg.
+		WithOS(param.OSFlavor).
 		WithStorageDriver(param.DockerStorageDriver).
-		WithNodes(param.NodeCount))
+		WithNodes(param.NodeCount)
+}
+
+func provisionNodes(g *gravity.TestContext, cfg gravity.ProvisionerConfig, param installParam) (gravity.Cluster, error) {
+	return g.Provision(withInstallParam(cfg, param))
 }
 
 func install(p interface{}) (gravity.TestFunc, error) {

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -104,9 +104,11 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 			g.Logger().WithFields(logrus.Fields{"roles": roles, "nodes": nodes}).
 				Info("roles after expand")
 
-			g.OK("remove old node", g.RemoveNode(nodes, removed))
+			g.OK("remove node", g.RemoveNode(nodes[0], removed))
+			g.OK("remove status", g.Status(nodes))
 		} else {
-			g.OK("remove lost node", g.RemoveNode(nodes, removed))
+			g.OK("remove lost node", g.RemoveNode(nodes[0], removed))
+			g.OK("remove status", g.Status(nodes))
 
 			roles, err := g.NodesByRole(nodes)
 			g.OK("node role after remove", err)

--- a/suite/sanity/sanity.go
+++ b/suite/sanity/sanity.go
@@ -23,6 +23,7 @@ func Suite() *config.Config {
 	cfg.Add("install", install, defaultInstallParam)
 	cfg.Add("recover", lossAndRecovery, lossAndRecoveryParam{installParam: defaultInstallParam})
 	cfg.Add("recoverV", lossAndRecoveryVariety, defaultInstallParam)
+	cfg.Add("shrink", shrink, defaultInstallParam)
 	cfg.Add("upgrade", upgrade, upgradeParam{installParam: defaultInstallParam})
 	// upgrade3lts is vestigial alias for upgrade needed for backwards compat
 	// to prevent issues like:

--- a/suite/sanity/shrink.go
+++ b/suite/sanity/shrink.go
@@ -1,0 +1,47 @@
+package sanity
+
+import (
+	"github.com/gravitational/robotest/infra/gravity"
+
+	"github.com/sirupsen/logrus"
+)
+
+func shrink(p interface{}) (gravity.TestFunc, error) {
+	param := p.(installParam)
+
+	return func(g *gravity.TestContext, cfg gravity.ProvisionerConfig) {
+
+		cfg = withInstallParam(cfg, param).WithNodes(param.NodeCount + 1)
+
+		cluster, err := g.Provision(cfg)
+		g.OK("Provision nodes.", err)
+		defer func() {
+			g.Maybe("Destroy.", cluster.Destroy())
+		}()
+
+		all := cluster.Nodes
+		target := make([]gravity.Gravity, 1)
+		copy(target, cluster.Nodes[0:1])
+		others := make([]gravity.Gravity, len(all)-1)
+		copy(others, cluster.Nodes[1:])
+		g.Logger().WithFields(logrus.Fields{"target": target, "others": others}).Info("Select join/shrink target.")
+
+		g.OK("Download installer.", g.SetInstaller(all, cfg.InstallerURL, "install"))
+
+		g.OK("Install.", g.OfflineInstall(others, param.InstallParam))
+		g.OK("Install status.", g.Status(others))
+
+		joinParam := param.InstallParam
+		joinParam.Role = "knode"
+		g.OK("Expand.", g.Expand(others, target, joinParam))
+		g.OK("Expand status.", g.Status(all))
+
+		roles, err := g.NodesByRole(all)
+		g.OK("Query roles.", err)
+		g.Logger().WithFields(logrus.Fields{"roles": roles, "nodes": all}).Info("Node roles after expand.")
+
+		g.OK("Shrink.", g.Shrink(others, target))
+		g.OK("Shrink status.", g.Status(others))
+
+	}, nil
+}


### PR DESCRIPTION
Fixes #188.

I also refactored RemoveNode -> RemoveNodes for signature consistency
with Expand() and the unused ShrinkLeave().

### Testing After PR Feedback
5.5.40 [shrink logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-22T02:37:23.621000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%225b9df45e-f63f-47f5-babb-2f881dfb4b1f%22%0Alabels.__suite__%3D%227b42a0e3-9bce-42ce-82b1-c608492facb3%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-22T01:37:24.121Z&dateRangeEnd=2020-05-22T02:37:24.121Z&interval=PT1H&scrollTimestamp=2020-05-22T02:37:04.145726434Z)

### Testing Done
7.0.5 [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-20T05:02:13.690000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22e1dbcb40-c486-40a5-b294-4f8578d0db80%22%0Alabels.__suite__%3D%22188d1189-da74-47d8-89c0-3a4ed268ea08%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-20T03:39:51.336Z&interval=PT1H&scrollTimestamp=2020-05-20T04:47:53.927326441Z&dateRangeUnbound=forwardInTime)

Unfortunately, reproing https://github.com/gravitational/gravity/issues/1445 is flaky.  Here are two example runs:

5.5.40 [repro](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-20T04:40:22.738000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%220081a1c1-d0e5-459b-ae00-161b6700cb82%22%0Alabels.__suite__%3D%2276ae03e0-d6fa-4bf8-a250-fd065625d691%22&dateRangeStart=2020-05-20T03:42:14.800Z&dateRangeEnd=2020-05-20T04:42:14.800Z&interval=PT1H&scrollTimestamp=2020-05-20T04:09:28.820653764Z) (there was an unrelated failure to log/cleanup on this run)
5.5.40 [no repro](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-20T04:33:18.953000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%226fb81578-2588-462e-8b00-1bec322971d1%22%0Alabels.__suite__%3D%22bdea6413-a8ce-4216-8fcf-e29eae77bb0c%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-20T03:33:19.512Z&dateRangeEnd=2020-05-20T04:33:19.512Z&interval=PT1H&scrollTimestamp=2020-05-20T04:32:31.947230235Z)

As I've already invested the better part of a week into manually reproing, and attempting to debug, I'm calling this good enough for now.  Let me know if you have ideas about how we could make this test (or the product) more deterministic.
