### PR TITLE
Check for "active" status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	go.opencensus.io v0.0.0-20181129005706-8b019f31bc1c // indirect
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20181128211412-28207608b838
-	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
 	google.golang.org/api v0.0.0-20181129220737-af4fc4062c26 // indirect
 	google.golang.org/appengine v1.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20181202183823-bd91e49a0898 // indirect

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -232,7 +232,7 @@ func (c *TestContext) upgrade(master Gravity, numNodes int) error {
 
 // ExecScript will run and execute a script on all nodes
 func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []string) error {
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.ExecScript)
 	defer cancel()
 
 	errs := make(chan error, len(nodes))

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -205,7 +205,7 @@ func (c *TestContext) uploadInstaller(master Gravity, nodes []Gravity, installer
 		return trace.Wrap(err)
 	}
 
-	err = c.Status(nodes)
+	err = c.WaitForActiveStatus(nodes)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/infra/gravity/cluster_resize.go
+++ b/infra/gravity/cluster_resize.go
@@ -18,7 +18,7 @@ func (c *TestContext) Expand(currentCluster, nodesToJoin []Gravity, p InstallPar
 	// status is solely used for gathering the join token, can this be replaced
 	// with InstallParam.Token -- 2020-05 walt
 	peer := currentCluster[0]
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.NodeStatus)
 	defer cancel()
 	status, err := peer.Status(ctx)
 	if err != nil {
@@ -41,7 +41,7 @@ func (c *TestContext) Expand(currentCluster, nodesToJoin []Gravity, p InstallPar
 // JoinNode has one node join a peer already in a cluster
 func (c *TestContext) JoinNode(peer, nodeToJoin Gravity, p InstallParam) error {
 
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.NodeStatus)
 	defer cancel()
 	status, err := peer.Status(ctx)
 	if err != nil {

--- a/infra/gravity/cluster_status.go
+++ b/infra/gravity/cluster_status.go
@@ -17,8 +17,8 @@ type statusValidator func(s GravityStatus) error
 
 // checkActive returns an error if the cluster is degraded or state != active.
 func checkActive(s GravityStatus) error {
-	if s.Cluster.Status != constants.ClusterStateActive {
-		return trace.CompareFailed("expected state %q, found %q", constants.ClusterStateActive, s.Cluster.Status)
+	if s.Cluster.State != constants.ClusterStateActive {
+		return trace.CompareFailed("expected state %q, found %q", constants.ClusterStateActive, s.Cluster.State)
 	}
 	return nil
 }

--- a/infra/gravity/cluster_status.go
+++ b/infra/gravity/cluster_status.go
@@ -53,9 +53,8 @@ func (c *TestContext) CheckTimeSync(nodes []Gravity) error {
 		})
 	}
 
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.TimeSync)
 	defer cancel()
-
 	err := sshutils.CheckTimeSync(ctx, timeNodes)
 	return trace.Wrap(err)
 }
@@ -122,7 +121,7 @@ type ClusterNodesByRole struct {
 
 // NodesByRole will conveniently organize nodes according to their roles in cluster
 func (c *TestContext) NodesByRole(nodes []Gravity) (roles *ClusterNodesByRole, err error) {
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.Status)
+	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.ResolveInPlanet)
 	defer cancel()
 
 	roles = &ClusterNodesByRole{}

--- a/infra/gravity/cluster_status.go
+++ b/infra/gravity/cluster_status.go
@@ -130,6 +130,8 @@ func (c *TestContext) NodesByRole(nodes []Gravity) (roles *ClusterNodesByRole, e
 		return nil, trace.Wrap(err)
 	}
 
+	ctx, cancel = context.WithTimeout(c.ctx, c.timeouts.GetPods)
+	defer cancel()
 	// Run query on the apiserver
 	pods, err := KubectlGetPods(ctx, roles.ApiMaster, kubeSystemNS, appGravityLabel)
 	if err != nil {

--- a/infra/gravity/defaults.go
+++ b/infra/gravity/defaults.go
@@ -30,7 +30,8 @@ var DefaultTimeouts = OpTimeouts{
 	Upgrade:          time.Minute * 30, // upgrade threshold per node
 	Uninstall:        time.Minute * 5,  // uninstall threshold per node
 	UninstallApp:     time.Minute * 5,  // application uninstall threshold
-	Status:           time.Minute * 30, // sufficient for failover procedures
+	NodeStatus:       time.Minute * 1,  // limit for status to return on a single node
+	ClusterStatus:    time.Minute * 5,  // limit for status to queisce across the cluster
 	Leave:            time.Minute * 15, // threshold to leave cluster
 	CollectLogs:      time.Minute * 7,  // to collect logs from node
 	WaitForInstaller: time.Minute * 30, // wait for build to complete in parallel

--- a/infra/gravity/defaults.go
+++ b/infra/gravity/defaults.go
@@ -35,8 +35,8 @@ var DefaultTimeouts = OpTimeouts{
 	CollectLogs:      time.Minute * 7,  // to collect logs from node
 	WaitForInstaller: time.Minute * 30, // wait for build to complete in parallel
 	AutoScaling:      time.Minute * 10, // wait for autoscaling operation
-	TimeSync:         time.Minute * 30, // wait for ntp to converge
-	ResolveInPlanet:  time.Minute * 30, // resolve a hostname inside planet with dig
+	TimeSync:         time.Minute * 5,  // wait for ntp to converge
+	ResolveInPlanet:  time.Minute * 1,  // resolve a hostname inside planet with dig
 	GetPods:          time.Minute * 1,  // use kubectl to query pods on the API master
-	ExecScript:       time.Minute * 30, // user provided script, this should be specified by the user
+	ExecScript:       time.Minute * 5,  // user provided script, this should be specified by the user
 }

--- a/infra/gravity/defaults.go
+++ b/infra/gravity/defaults.go
@@ -37,5 +37,6 @@ var DefaultTimeouts = OpTimeouts{
 	AutoScaling:      time.Minute * 10, // wait for autoscaling operation
 	TimeSync:         time.Minute * 30, // wait for ntp to converge
 	ResolveInPlanet:  time.Minute * 30, // resolve a hostname inside planet with dig
+	GetPods:          time.Minute * 1,  // use kubectl to query pods on the API master
 	ExecScript:       time.Minute * 30, // user provided script, this should be specified by the user
 }

--- a/infra/gravity/defaults.go
+++ b/infra/gravity/defaults.go
@@ -35,4 +35,7 @@ var DefaultTimeouts = OpTimeouts{
 	CollectLogs:      time.Minute * 7,  // to collect logs from node
 	WaitForInstaller: time.Minute * 30, // wait for build to complete in parallel
 	AutoScaling:      time.Minute * 10, // wait for autoscaling operation
+	TimeSync:         time.Minute * 30, // wait for ntp to converge
+	ResolveInPlanet:  time.Minute * 30, // resolve a hostname inside planet with dig
+	ExecScript:       time.Minute * 30, // user provided script, this should be specified by the user
 }

--- a/infra/gravity/gravity_test.go
+++ b/infra/gravity/gravity_test.go
@@ -16,7 +16,7 @@ func TestGravityOutput(t *testing.T) {
 		Cluster: ClusterStatus{
 			Cluster:     "testcluster",
 			Application: Application{Name: "telekube"},
-			Status:      "active",
+			State:       "active",
 			Token:       Token{Token: "fac3b88014367fe4e98a8664755e2be4"},
 			Nodes: []NodeStatus{
 				NodeStatus{Addr: "10.40.2.4"},
@@ -40,7 +40,7 @@ func TestHealthyStatusValidation(t *testing.T) {
 		Cluster: ClusterStatus{
 			Cluster:     "robotest",
 			Application: Application{Name: "telekube"},
-			Status:      "active",
+			State:       "active",
 			Token:       Token{Token: "ROBOTEST"},
 			Nodes: []NodeStatus{
 				NodeStatus{Addr: "10.1.2.3"},
@@ -63,7 +63,7 @@ func Test1523StatusValidation(t *testing.T) {
 		Cluster: ClusterStatus{
 			Cluster:     "robotest",
 			Application: Application{Name: "telekube"},
-			Status:      "degraded",
+			State:       "degraded",
 			Token:       Token{Token: "ROBOTEST"},
 			Nodes: []NodeStatus{
 				NodeStatus{Addr: "10.1.2.3"},

--- a/infra/gravity/gravity_test.go
+++ b/infra/gravity/gravity_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testStatusStr = []byte(`
+func TestGravityOutput(t *testing.T) {
+	var testStatusStr = []byte(`
 {"cluster":{"application":{"repository":"gravitational.io","name":"telekube","version":"0.0.1"},"state":"active","domain":"testcluster","token":{"token":"fac3b88014367fe4e98a8664755e2be4","expires":"0001-01-01T00:00:00Z","type":"expand","account_id":"00000000-0000-0000-0000-000000000001","site_domain":"testcluster","operation_id":"","user_email":"agent@testcluster"},"operation":{"type":"operation_install","id":"55298dfd-2094-47a3-a787-8b2a546c0fd1","state":"completed","created":"2008-01-01T12:00:00.0Z","progress":{"message":"Operation has completed","completion":100,"created":"2008-01-01T12:05:00.0Z"}},"system_status":1,"nodes":[{"hostname":"node-0","advertise_ip":"10.40.2.4","role":"master","profile":"node","status":"healthy"},{"hostname":"node-2","advertise_ip":"10.40.2.5","role":"master","profile":"node","status":"healthy"},{"hostname":"node-1","advertise_ip":"10.40.2.7","role":"master","profile":"node","status":"healthy"},{"hostname":"node-5","advertise_ip":"10.40.2.6","role":"node","profile":"node","status":"healthy"},{"hostname":"node-3","advertise_ip":"10.40.2.3","role":"node","profile":"node","status":"healthy"},{"hostname":"node-4","advertise_ip":"10.40.2.2","role":"node","profile":"node","status":"healthy"}]}}
 `)
-
-func TestGravityOutput(t *testing.T) {
 	expectedStatus := &GravityStatus{
 		Cluster: ClusterStatus{
 			Cluster:     "testcluster",
@@ -34,4 +33,43 @@ func TestGravityOutput(t *testing.T) {
 	err := parseStatus(&status)(bufio.NewReader(bytes.NewReader(testStatusStr)))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStatus, &status, "parseStatus")
+}
+
+func TestHealthyStatusValidation(t *testing.T) {
+	healthyStatus := GravityStatus{
+		Cluster: ClusterStatus{
+			Cluster:     "robotest",
+			Application: Application{Name: "telekube"},
+			Status:      "active",
+			Token:       Token{Token: "ROBOTEST"},
+			Nodes: []NodeStatus{
+				NodeStatus{Addr: "10.1.2.3"},
+				NodeStatus{Addr: "10.1.2.4"},
+				NodeStatus{Addr: "10.1.2.5"},
+			},
+		},
+	}
+	err := checkActive(healthyStatus)
+	assert.NoError(t, err)
+}
+
+// Test1523StatusValidation ensures expanding status is
+// identified as "unsafe to proceed" by Robotest.
+//
+// Expands may be unexpectedly seen after install as discussed
+// in https://github.com/gravitational/gravity/issues/1523.
+func Test1523StatusValidation(t *testing.T) {
+	nonActiveStatus := GravityStatus{
+		Cluster: ClusterStatus{
+			Cluster:     "robotest",
+			Application: Application{Name: "telekube"},
+			Status:      "degraded",
+			Token:       Token{Token: "ROBOTEST"},
+			Nodes: []NodeStatus{
+				NodeStatus{Addr: "10.1.2.3"},
+			},
+		},
+	}
+	err := checkActive(nonActiveStatus)
+	assert.Error(t, err)
 }

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -125,11 +125,6 @@ type JoinCmd struct {
 	StateDir string
 }
 
-// IsDegraded determines whether the cluster is in degraded state
-func (r GravityStatus) IsDegraded() bool {
-	return r.Cluster.Status == "degraded"
-}
-
 // GravityStatus describes the status of the Gravity cluster
 type GravityStatus struct {
 	// Cluster describes the cluster status
@@ -284,26 +279,7 @@ var installCmdTemplate = template.Must(
 `))
 
 // Status queries cluster status
-func (g *gravity) Status(ctx context.Context) (status *GravityStatus, err error) {
-	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = defaults.ClusterStatusTimeout
-	err = wait.RetryWithInterval(ctx, b, func() (err error) {
-		status, err = g.status(ctx)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if status.IsDegraded() {
-			return trace.BadParameter("degraded")
-		}
-		return nil
-	}, g.log)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return status, nil
-}
-
-func (g *gravity) status(ctx context.Context) (*GravityStatus, error) {
+func (g *gravity) Status(ctx context.Context) (*GravityStatus, error) {
 	cmd := fmt.Sprintf("sudo gravity status --output=json --system-log-file=%v",
 		defaults.AgentLogPath)
 	status := GravityStatus{}

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -139,6 +139,8 @@ type ClusterStatus struct {
 	Cluster string `json:"domain"`
 	// State is the cluster state
 	State string `json:"state"`
+	// SystemStatus is the cluster status, see https://github.com/gravitational/satellite/blob/7.1.0/agent/proto/agentpb/agent.proto#L50-L54
+	SystemStatus int `json:"system_status"`
 	// Token is secure token which prevents rogue nodes from joining the cluster during installation
 	Token Token `json:"token"`
 	// Nodes describes the nodes in the cluster

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -137,8 +137,8 @@ type ClusterStatus struct {
 	Application Application `json:"application"`
 	// Cluster is the name of the cluster
 	Cluster string `json:"domain"`
-	// Status is the cluster status
-	Status string `json:"state"`
+	// State is the cluster state
+	State string `json:"state"`
 	// Token is secure token which prevents rogue nodes from joining the cluster during installation
 	Token Token `json:"token"`
 	// Nodes describes the nodes in the cluster

--- a/infra/gravity/testcontext.go
+++ b/infra/gravity/testcontext.go
@@ -20,11 +20,12 @@ const (
 
 // OpTimeouts defines per-node, per-operation timeouts which would be used to determine
 // whether test must be failed
-// provisioner has its own timeout / restart logic which is dependant on cloud provider and terraform
+// provisioner has its own timeout / restart logic which is dependent on cloud provider and terraform
 type OpTimeouts struct {
 	Install          time.Duration
 	Upgrade          time.Duration
-	Status           time.Duration
+	NodeStatus       time.Duration
+	ClusterStatus    time.Duration
 	Uninstall        time.Duration
 	UninstallApp     time.Duration
 	Leave            time.Duration

--- a/infra/gravity/testcontext.go
+++ b/infra/gravity/testcontext.go
@@ -31,6 +31,9 @@ type OpTimeouts struct {
 	CollectLogs      time.Duration
 	WaitForInstaller time.Duration
 	AutoScaling      time.Duration
+	TimeSync         time.Duration
+	ResolveInPlanet  time.Duration
+	ExecScript       time.Duration
 }
 
 // TestContext aggregates common parameters for better test suite readability

--- a/infra/gravity/testcontext.go
+++ b/infra/gravity/testcontext.go
@@ -33,6 +33,7 @@ type OpTimeouts struct {
 	AutoScaling      time.Duration
 	TimeSync         time.Duration
 	ResolveInPlanet  time.Duration
+	GetPods          time.Duration
 	ExecScript       time.Duration
 }
 

--- a/infra/gravity/testdata/status-degraded-1641.json
+++ b/infra/gravity/testdata/status-degraded-1641.json
@@ -1,0 +1,129 @@
+{
+  "cluster": {
+    "application": {
+      "repository": "gravitational.io",
+      "name": "telekube",
+      "version": "6.1.27"
+    },
+    "state": "active",
+    "domain": "robotest-unit-test",
+    "token": {
+      "token": "ROBOTEST",
+      "expires": "0001-01-01T00:00:00Z",
+      "type": "expand",
+      "account_id": "00000000-0000-0000-0000-000000000001",
+      "site_domain": "robotest-unit-test",
+      "operation_id": "42178dd3-291c-4dd7-a870-87a1ade5d93a",
+      "user_email": "agent@robotest-unit-test"
+    },
+    "operation": {
+      "type": "operation_install",
+      "id": "42178dd3-291c-4dd7-a870-87a1ade5d93a",
+      "state": "completed",
+      "created": "2020-05-27T21:04:41.962836059Z",
+      "description": "3-node install",
+      "progress": {
+        "message": "Operation has completed",
+        "completion": 100,
+        "created": "2020-05-27T21:05:20.934000242Z"
+      }
+    },
+    "endpoints": {
+      "applications": {
+        "Endpoints": [
+          {
+            "application": {
+              "repository": "gravitational.io",
+              "name": "telekube",
+              "version": "6.1.27"
+            },
+            "endpoints": [
+              {
+                "name": "Gravity Control Panel",
+                "description": "Local administrative user interface of this Gravity cluster\n",
+                "addresses": [
+                  "https://10.138.0.23:32009",
+                  "https://10.138.0.53:32009",
+                  "https://10.138.0.56:32009"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "cluster": {
+        "auth_gateway": [
+          "10.138.0.56:32009",
+          "10.138.0.23:32009",
+          "10.138.0.53:32009"
+        ],
+        "ui": [
+          "https://10.138.0.56:32009",
+          "https://10.138.0.23:32009",
+          "https://10.138.0.53:32009"
+        ]
+      }
+    },
+    "Extension": {},
+    "server_version": {
+      "edition": "open-source",
+      "version": "6.1.27",
+      "gitCommit": "1787b91072d649e6fcb761c803a8690d432e07d6",
+      "helm": "v2.14"
+    },
+    "client_version": {
+      "edition": "open-source",
+      "version": "6.1.27",
+      "gitCommit": "1787b91072d649e6fcb761c803a8690d432e07d6",
+      "helm": "v2.14"
+    },
+    "system_status": 2,
+    "nodes": [
+      {
+        "hostname": "robotest-unit-test-node-1",
+        "advertise_ip": "10.138.0.56",
+        "role": "master",
+        "profile": "node",
+        "status": "degraded",
+        "failed_probes": [
+          "etcd-healthz (unexpected HTTP status: Service Unavailable)"
+        ],
+        "teleport_node": {
+          "hostname": "robotest-unit-test-node-1",
+          "advertise_ip": "10.138.0.56",
+          "public_ip": "",
+          "profile": "node",
+          "instance_type": ""
+        }
+      },
+      {
+        "hostname": "robotest-unit-test-node-0",
+        "advertise_ip": "10.138.0.23",
+        "role": "master",
+        "profile": "node",
+        "status": "healthy",
+        "teleport_node": {
+          "hostname": "robotest-unit-test-node-0",
+          "advertise_ip": "10.138.0.23",
+          "public_ip": "",
+          "profile": "node",
+          "instance_type": ""
+        }
+      },
+      {
+        "hostname": "robotest-unit-test-node-2",
+        "advertise_ip": "10.138.0.53",
+        "role": "master",
+        "profile": "node",
+        "status": "healthy",
+        "teleport_node": {
+          "hostname": "robotest-unit-test-node-2",
+          "advertise_ip": "10.138.0.53",
+          "public_ip": "",
+          "profile": "node",
+          "instance_type": ""
+        }
+      }
+    ]
+  }
+}

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -64,4 +64,9 @@ const (
 	ClusterStateActive = "active"
 	// ClusterStateDegraded is unhealthy.
 	ClusterStateDegraded = "degraded"
+
+	// SystemStatus_* consts come from https://github.com/gravitational/satellite/blob/7.1.0/agent/proto/agentpb/agent.pb.go#L28-L32
+
+	SystemStatus_Running  = 1
+	SystemStatus_Degraded = 2
 )

--- a/lib/constants/constants.go
+++ b/lib/constants/constants.go
@@ -54,3 +54,14 @@ const (
 	// Ops specifies a special cloud provider - a telekube Ops Center
 	Ops = "ops"
 )
+
+// Gravity API constants redeclared here to avoid extra dependencies solely to
+// get these values
+const (
+	// ClusterState* consts come from https://github.com/gravitational/gravity/blob/7.0.0/lib/ops/constants.go#L64-L93
+
+	// ClusterStateActive is healthy and not running any operations.
+	ClusterStateActive = "active"
+	// ClusterStateDegraded is unhealthy.
+	ClusterStateDegraded = "degraded"
+)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -30,6 +30,9 @@ const (
 	// NodeRole is the default role when installing/joining a node
 	NodeRole = "node"
 
+	// GravityStateActive is https://github.com/gravitational/gravity/blob/7.0.0/lib/ops/constants.go#L71
+	GravityStateActive = "active"
+
 	// GravityDir is the default location of all gravity data on a node
 	GravityDir = "/var/lib/gravity"
 
@@ -39,9 +42,6 @@ const (
 
 	// TerraformRetryDelay
 	TerraformRetryDelay = 5 * time.Minute
-
-	// ClusterStatusTimeout specifies the maximum amount of time to wait for cluster status
-	ClusterStatusTimeout = 5 * time.Minute
 
 	// TerraformRetries is the maximum number of attempts to reprovision the
 	// infrastructure upon encountering an error from 'terraform apply'

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -30,9 +30,6 @@ const (
 	// NodeRole is the default role when installing/joining a node
 	NodeRole = "node"
 
-	// GravityStateActive is https://github.com/gravitational/gravity/blob/7.0.0/lib/ops/constants.go#L71
-	GravityStateActive = "active"
-
 	// GravityDir is the default location of all gravity data on a node
 	GravityDir = "/var/lib/gravity"
 

--- a/suite/sanity/autoscale.go
+++ b/suite/sanity/autoscale.go
@@ -15,19 +15,20 @@ func autoscale(p interface{}) (gravity.TestFunc, error) {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		g.OK("status", g.Status(cluster.Nodes))
+		g.OK("wait for active status on masters", g.WaitForActiveStatus(cluster.Nodes))
 		g.OK("time sync", g.CheckTimeSync(cluster.Nodes))
 
 		// Scale Up
 		workers, err := g.AutoScale(3)
 		g.OK("asg-up", err)
-		g.OK("status-masters", g.Status(cluster.Nodes))
-		g.OK("status-workers", g.Status(workers))
+		g.OK("wait for active status on masters", g.WaitForActiveStatus(cluster.Nodes))
+		g.OK("wait for active status on asg workers", g.WaitForActiveStatus(workers))
 
 		// Scale Down
 		workers, err = g.AutoScale(1)
 		g.OK("asg-down", err)
-		g.OK("status-masters", g.Status(cluster.Nodes))
-		g.OK("status-workers", g.Status(workers))
+		g.OK("wait for active status on masters", g.WaitForActiveStatus(cluster.Nodes))
+		_, err = g.Status(workers)
+		g.OK("status on asg workers", err)
 	}, nil
 }

--- a/suite/sanity/install.go
+++ b/suite/sanity/install.go
@@ -62,7 +62,7 @@ func install(p interface{}) (gravity.TestFunc, error) {
 				g.ExecScript(cluster.Nodes, param.Script.Url, param.Script.Args))
 		}
 		g.OK("application installed", g.OfflineInstall(cluster.Nodes, param.InstallParam))
-		g.OK("status", g.Status(cluster.Nodes))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))
 	}, nil
 }
 

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -84,13 +84,13 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 
 		nodes := cluster.Nodes[0:param.NodeCount]
 		g.OK("install", g.OfflineInstall(nodes, param.InstallParam))
-		g.OK("install status", g.Status(nodes))
+		g.OK("wait for active status", g.WaitForActiveStatus(nodes))
 
 		nodes, removed, err := removeNode(g, nodes, param.ReplaceNodeType, param.PowerOff)
 		g.OK(fmt.Sprintf("node for removal=%v, poweroff=%v", removed, param.PowerOff), err)
 
 		now := time.Now()
-		g.OK("wait for cluster to be ready", g.Status(nodes))
+		g.OK("wait for active status", g.WaitForActiveStatus(nodes))
 		g.Logger().WithFields(logrus.Fields{"nodes": nodes, "elapsed": fmt.Sprintf("%v", time.Since(now))}).
 			Info("cluster is available")
 
@@ -105,10 +105,10 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 				Info("roles after expand")
 
 			g.OK("remove node", g.RemoveNode(nodes[0], removed))
-			g.OK("remove status", g.Status(nodes))
+			g.OK("wait for active status", g.WaitForActiveStatus(nodes))
 		} else {
 			g.OK("remove lost node", g.RemoveNode(nodes[0], removed))
-			g.OK("remove status", g.Status(nodes))
+			g.OK("wait for active status", g.WaitForActiveStatus(nodes))
 
 			roles, err := g.NodesByRole(nodes)
 			g.OK("node role after remove", err)

--- a/suite/sanity/resize.go
+++ b/suite/sanity/resize.go
@@ -41,11 +41,11 @@ func resize(p interface{}) (gravity.TestFunc, error) {
 		g.OK("download installer", g.SetInstaller(cluster.Nodes, cfg.InstallerURL, "install"))
 		g.OK(fmt.Sprintf("install on %d node", param.NodeCount),
 			g.OfflineInstall(cluster.Nodes[0:param.NodeCount], param.InstallParam))
-		g.OK("status", g.Status(cluster.Nodes[0:param.NodeCount]))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[0:param.NodeCount]))
 		g.OK("time sync", g.CheckTimeSync(cluster.Nodes))
 		g.OK(fmt.Sprintf("expand to %d nodes", param.ToNodes),
 			g.Expand(cluster.Nodes[0:param.NodeCount], cluster.Nodes[param.NodeCount:param.ToNodes],
 				param.InstallParam))
-		g.OK("status", g.Status(cluster.Nodes[0:param.ToNodes]))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[0:param.ToNodes]))
 	}, nil
 }

--- a/suite/sanity/resize.go
+++ b/suite/sanity/resize.go
@@ -40,12 +40,12 @@ func resize(p interface{}) (gravity.TestFunc, error) {
 
 		g.OK("download installer", g.SetInstaller(cluster.Nodes, cfg.InstallerURL, "install"))
 		g.OK(fmt.Sprintf("install on %d node", param.NodeCount),
-			g.OfflineInstall(cluster.Nodes[0:param.NodeCount], param.InstallParam))
-		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[0:param.NodeCount]))
+			g.OfflineInstall(cluster.Nodes[:param.NodeCount], param.InstallParam))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[:param.NodeCount]))
 		g.OK("time sync", g.CheckTimeSync(cluster.Nodes))
 		g.OK(fmt.Sprintf("expand to %d nodes", param.ToNodes),
-			g.Expand(cluster.Nodes[0:param.NodeCount], cluster.Nodes[param.NodeCount:param.ToNodes],
+			g.Expand(cluster.Nodes[:param.NodeCount], cluster.Nodes[param.NodeCount:param.ToNodes],
 				param.InstallParam))
-		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[0:param.ToNodes]))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[:param.ToNodes]))
 	}, nil
 }

--- a/suite/sanity/shrink.go
+++ b/suite/sanity/shrink.go
@@ -29,19 +29,19 @@ func shrink(p interface{}) (gravity.TestFunc, error) {
 		g.OK("Download installer.", g.SetInstaller(all, cfg.InstallerURL, "install"))
 
 		g.OK("Install.", g.OfflineInstall(others, param.InstallParam))
-		g.OK("Install status.", g.Status(others))
+		g.OK("Wait for active status.", g.WaitForActiveStatus(others))
 
 		joinParam := param.InstallParam
 		joinParam.Role = "knode"
 		g.OK("Expand.", g.Expand(others, target, joinParam))
-		g.OK("Expand status.", g.Status(all))
+		g.OK("Wait for active status.", g.WaitForActiveStatus(all))
 
 		roles, err := g.NodesByRole(all)
 		g.OK("Query roles.", err)
 		g.Logger().WithFields(logrus.Fields{"roles": roles, "nodes": all}).Info("Node roles after expand.")
 
 		g.OK("Shrink.", g.Shrink(others, target))
-		g.OK("Shrink status.", g.Status(others))
+		g.OK("Wait for active status.", g.WaitForActiveStatus(others))
 
 	}, nil
 }

--- a/suite/sanity/upgrade.go
+++ b/suite/sanity/upgrade.go
@@ -35,8 +35,8 @@ func upgrade(p interface{}) (gravity.TestFunc, error) {
 
 		g.OK("base installer", g.SetInstaller(cluster.Nodes, param.BaseInstallerURL, "base"))
 		g.OK("install", g.OfflineInstall(cluster.Nodes, param.InstallParam))
-		g.OK("status", g.Status(cluster.Nodes))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))
 		g.OK("upgrade", g.Upgrade(cluster.Nodes, cfg.InstallerURL, cfg.GravityURL, "upgrade"))
-		g.OK("status", g.Status(cluster.Nodes))
+		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))
 	}, nil
 }


### PR DESCRIPTION
## Description
This change introduces more rigorous status checking in all suite tests cases.  Specifically, we go from `state != degraded` (30m timeout) to `state = active && system_status = Running` (5m timeout).

## Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* Internal change (not necessarily a bug fix or a new feature)

I mention breaking because the 30m -> 5m timeout may break some of the tests cases we don't run presently.  It should be safe for all currently run test cases, because they wait for operations to complete before querying status.

## Linked tickets and other PRs

Fixes #225.
Heavily rewrites the code introduced in #136.

## TODOs
- [x] Self-review the change
- [x] Write documentation
- [x] Address review feedback
- [x] Write automated tests

Manual testing
- [x] install testing
- [x] upgrade testing
- [x] shrink testing
- [x] resize/expand testing

## Testing done
Added unit tests for status validations. 

Logs from end-to-end runs:
* [upgrade](https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%227716b2b9-495f-4994-b9df-4ed8b1eca546%22%0Alabels.__suite__%3D%2286f73a17-e7ed-4c5a-8e18-752345982871%22%0Aseverity%3E%3DINFO&authuser=0&expandAll=false&project=kubeadm-167321)
* [install](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-06-04T17:29:38.218000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2231641fab-7122-405a-bc8f-661bc6ce3dcf%22%0Alabels.__suite__%3D%2218283bab-ebfc-4f94-851e-4e8b52e79a40%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-06-04T16:29:38.731Z&dateRangeEnd=2020-06-04T17:29:38.731Z&interval=PT1H&scrollTimestamp=2020-06-04T17:29:08.893390113Z) (updated after round 2 of changes)
* [shrink](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-28T20:20:45.516000000Z&customFacets=&limitCustomFacetWidth=true&interval=CUSTOM&scrollTimestamp=2020-05-27T20:56:28.810552801Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22b32c7b8c-931b-4fb7-8f35-86e319db8ff2%22%0Alabels.__suite__%3D%225199396c-9a77-4d8c-8a95-4cc93b923652%22%0Aseverity%3E%3DINFO&dateRangeEnd=2020-05-28T20:20:43.140Z&dateRangeUnbound=backwardInTime) (updated after review feedback)
* [resize/expand](https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%228eba6e3a-8072-4cd4-a519-84dddba1ac8c%22%0Alabels.__suite__%3D%2261652cea-69b5-4c70-b99c-d5396fe883a1%22%0Aseverity%3E%3DINFO&authuser=0&expandAll=false&project=kubeadm-167321) (updated after review feedback)
