### PR TITLE
Refactor ExecScript timeout to be user specified.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test: ## Run unit tests.
 	docker run $(DOCKERFLAGS) \
 		--env="GO111MODULE=off" \
 		$(BUILDBOX) \
-		dumb-init go test -cover -race -v ./infra/...
+		dumb-init go test -cover -race -v ./infra/... ./lib/config/...
 
 .PHONY: lint
 lint: ## Run static analysis against source code.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/google/go-cmp v0.4.1
 	github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23
 	github.com/gravitational/log v0.0.0-20200127200505-fdffa14162b0 // indirect
 	github.com/gravitational/trace v1.1.11

--- a/infra/gravity/cluster_install.go
+++ b/infra/gravity/cluster_install.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gravitational/robotest/infra/providers/gce"
 	"github.com/gravitational/robotest/lib/constants"
@@ -231,8 +232,8 @@ func (c *TestContext) upgrade(master Gravity, numNodes int) error {
 }
 
 // ExecScript will run and execute a script on all nodes
-func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []string) error {
-	ctx, cancel := context.WithTimeout(c.ctx, c.timeouts.ExecScript)
+func (c *TestContext) ExecScript(nodes []Gravity, scriptUrl string, args []string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(c.ctx, timeout)
 	defer cancel()
 
 	errs := make(chan error, len(nodes))

--- a/infra/gravity/defaults.go
+++ b/infra/gravity/defaults.go
@@ -39,5 +39,4 @@ var DefaultTimeouts = OpTimeouts{
 	TimeSync:         time.Minute * 5,  // wait for ntp to converge
 	ResolveInPlanet:  time.Minute * 1,  // resolve a hostname inside planet with dig
 	GetPods:          time.Minute * 1,  // use kubectl to query pods on the API master
-	ExecScript:       time.Minute * 5,  // user provided script, this should be specified by the user
 }

--- a/infra/gravity/testcontext.go
+++ b/infra/gravity/testcontext.go
@@ -35,7 +35,6 @@ type OpTimeouts struct {
 	TimeSync         time.Duration
 	ResolveInPlanet  time.Duration
 	GetPods          time.Duration
-	ExecScript       time.Duration
 }
 
 // TestContext aggregates common parameters for better test suite readability

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,0 +1,191 @@
+package config
+
+/*
+ The tests within this file provide minimal testing for Robotest's test configuration DSL,
+ and also serve as examples of how custom test parameters can be declared, validated, and
+ and have defaults provided.
+*/
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/robotest/infra/gravity"
+	"github.com/gravitational/trace"
+)
+
+// defaultTimeout is meaningless test data, it could be any duration
+var defaultTimeout = 5 * time.Second
+
+// testParam is an artificial struct similar to suite/sanity/install.go:installParam.
+type testParam struct {
+	UID       uint             `json:"uid"`
+	Username  string           `json:"user"`
+	Operation *nestedTestParam `json:"operation"`
+}
+
+// CheckAndSetDefaults provides some basic default logic validation for testParam.
+//
+// This is provided as an example of what sort of custom validation can be done
+// by fulfilling the defaulter interface.
+func (r *testParam) CheckAndSetDefaults() error {
+	var expected string
+	switch r.UID {
+	case 0:
+		expected = "root"
+	case 1:
+		expected = "daemon"
+	default:
+		return trace.BadParameter("unknown UID %v", r.UID)
+	}
+	if r.Username == "" {
+		r.Username = expected
+	} else {
+		if r.Username != expected {
+			return trace.BadParameter("username %q does not match UID %v", r.Username, r.UID)
+		}
+	}
+	if r.Operation != nil {
+		if err := r.Operation.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// nestedTestParam is intended to be a struct within a struct.
+
+// This demonstrates validation and defaults for potentially nil sub parameters.
+type nestedTestParam struct {
+	Name    string   `json:"name" validate:"required"`
+	Timeout *Timeout `json:"timeout"`
+}
+
+func (r *nestedTestParam) CheckAndSetDefaults() error {
+	if r.Timeout == nil {
+		r.Timeout = &Timeout{defaultTimeout}
+	} else {
+		if r.Timeout.Duration < 0 {
+			return trace.BadParameter("timeout must be >= 0")
+		}
+	}
+	if r.Name == "" {
+		return trace.BadParameter("operation name must be specified")
+	}
+	return nil
+}
+
+// exampleTest is an example of a test generator that robotest could run, utilizing
+// testParam and nestedTestParam
+func exampleTest(p interface{}) (gravity.TestFunc, error) {
+	param := p.(testParam)
+	return func(g *gravity.TestContext, cfg gravity.ProvisionerConfig) {
+		out, _ := json.Marshal(param)
+		fmt.Println(string(out))
+	}, nil
+}
+
+func TestCompleteParamValidation(t *testing.T) {
+	data := []byte(`{"uid":1,"user":"daemon","operation":{"name":"start","timeout":"30s"}}`)
+	var p testParam
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Error(err)
+	}
+	if err := checkAndSetDefaults(&p); err != nil {
+		t.Error(err)
+	}
+	expected := testParam{
+		UID:       1,
+		Username:  "daemon",
+		Operation: &nestedTestParam{Name: "start", Timeout: &Timeout{30 * time.Second}},
+	}
+	if diff := cmp.Diff(expected, p); diff != "" {
+		t.Errorf("param mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPartialParamValidation(t *testing.T) {
+	data := []byte(`{"uid":1}`)
+	var p testParam
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Error(err)
+	}
+	if err := checkAndSetDefaults(&p); err != nil {
+		t.Error(err)
+	}
+	expected := testParam{UID: 1, Username: "daemon"}
+	if diff := cmp.Diff(expected, p); diff != "" {
+		t.Errorf("param mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestInvalidUIDParamValidation(t *testing.T) {
+	data := []byte(`{"uid":1000,"user":"centos"}`)
+	var p testParam
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Error(err)
+	}
+	err := checkAndSetDefaults(&p)
+	if err == nil {
+		t.Error("expected an error")
+	}
+	if !trace.IsBadParameter(err) {
+		t.Errorf("expected a bad parameter error, got %v", err)
+	}
+}
+
+func TestNilableNestedParamDefault(t *testing.T) {
+	data := []byte(`{"uid":1,"operation":{"name":"stop"}}`)
+	var p testParam
+	if err := json.Unmarshal(data, &p); err != nil {
+		t.Error(err)
+	}
+	if err := checkAndSetDefaults(&p); err != nil {
+		t.Error(err)
+	}
+	expected := testParam{
+		UID:       1,
+		Username:  "daemon",
+		Operation: &nestedTestParam{Name: "stop", Timeout: &Timeout{defaultTimeout}},
+	}
+	if diff := cmp.Diff(expected, p); diff != "" {
+		t.Errorf("param mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMakeFunction(t *testing.T) {
+	var defaults testParam
+	data := `{"uid":0,"operation":{"name":"stop"}}`
+	entry, err := makeFunction(exampleTest, data, defaults)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := testParam{
+		UID:       0,
+		Username:  "root",
+		Operation: &nestedTestParam{Name: "stop", Timeout: &Timeout{defaultTimeout}},
+	}
+	if diff := cmp.Diff(expected, entry.Param); diff != "" {
+		t.Errorf("param mismatch (-want +got):\n%s", diff)
+	}
+	// run the following to make sure it doesn't panic
+	testFunc := entry.TestFunc
+	testFunc(&gravity.TestContext{}, gravity.ProvisionerConfig{})
+
+}
+
+func TestMakeFunctionNoData(t *testing.T) {
+	var defaults testParam
+	var data string
+	_, err := makeFunction(exampleTest, data, defaults)
+	if err == nil {
+		t.Error("expected an error")
+	}
+	if !trace.IsBadParameter(err) {
+		t.Errorf("expected a bad parameter error, got %v", err)
+	}
+
+}

--- a/lib/config/duration.go
+++ b/lib/config/duration.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gravitational/trace"
+)
+
+// Timeout provides "human" json serialization/deserialization such as "1m" or "1h" for time.Duration.
+//
+// For further information, see:
+//   https://github.com/golang/go/issues/10275
+//   https://stackoverflow.com/questions/48050945/how-to-unmarshal-json-into-durations
+type Timeout struct {
+	time.Duration
+}
+
+func (d Timeout) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Timeout) UnmarshalJSON(buf []byte) error {
+	var data string
+	if err := json.Unmarshal(buf, &data); err != nil {
+		return trace.BadParameter("cannot parse %q as duration: %v", buf, err)
+	}
+	dur, err := time.ParseDuration(data)
+	if err != nil {
+		return trace.BadParameter("cannot parse %q as duration: %v", data, err)
+	}
+	if dur < 0 {
+		return trace.BadParameter("timeout must be >= 0")
+	}
+	d.Duration = dur
+	return nil
+}

--- a/lib/config/duration_test.go
+++ b/lib/config/duration_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+type TestMessage struct {
+	Timeout Timeout `json:"timeout"`
+}
+
+func TestJsonDeserialization(t *testing.T) {
+	data := []byte(`{"timeout":"30s"}`)
+	var msg TestMessage
+	err := json.Unmarshal(data, &msg)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInvalidDeserialization(t *testing.T) {
+	data := []byte(`{"timeout":3600}`)
+	var msg TestMessage
+	err := json.Unmarshal(data, &msg)
+	if err == nil {
+		t.Errorf("Expected to get an error when deserializing an unqualified integer.")
+	}
+}
+
+func TestDurationSerialization(t *testing.T) {
+	delta, err := time.ParseDuration("24h")
+	if err != nil {
+		t.Error(err)
+	}
+	msg := TestMessage{Timeout{delta}}
+	data, err := json.Marshal(&msg)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := []byte(`{"timeout":"24h0m0s"}`)
+	if !bytes.Equal(data, expected) {
+		t.Errorf("deserializing 24h, expected %q, got %q", expected, data)
+	}
+
+}

--- a/suite/sanity/install.go
+++ b/suite/sanity/install.go
@@ -1,7 +1,11 @@
 package sanity
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gravitational/robotest/infra/gravity"
+	"github.com/gravitational/robotest/lib/config"
 
 	"cloud.google.com/go/bigquery"
 )
@@ -15,8 +19,22 @@ type installParam struct {
 }
 
 type scriptParam struct {
-	Url  string   `json:"url" validate:"required"`
-	Args []string `json:"args"`
+	Url     string         `json:"url" validate:"required"`
+	Args    []string       `json:"args"`
+	Timeout config.Timeout `json:"timeout"`
+}
+
+// a hack to set default values when deserializing optional/nil-able structs
+// in this case, if the user doesn't specify a script timeout, prefer a non-zero timeout
+func (p *scriptParam) UnmarshalJSON(data []byte) error {
+	type alias scriptParam // to prevent Unmarshal recursion
+	defaults := alias{Timeout: config.Timeout{time.Minute * 5}}
+	err := json.Unmarshal(data, &defaults)
+	if err != nil {
+		return err
+	}
+	*p = scriptParam(defaults)
+	return nil
 }
 
 func (p installParam) Save() (row map[string]bigquery.Value, insertID string, err error) {
@@ -59,7 +77,7 @@ func install(p interface{}) (gravity.TestFunc, error) {
 		g.OK("installer downloaded", g.SetInstaller(cluster.Nodes, installerURL, "install"))
 		if param.Script != nil {
 			g.OK("post bootstrap script",
-				g.ExecScript(cluster.Nodes, param.Script.Url, param.Script.Args))
+				g.ExecScript(cluster.Nodes, param.Script.Url, param.Script.Args, param.Script.Timeout.Duration))
 		}
 		g.OK("application installed", g.OfflineInstall(cluster.Nodes, param.InstallParam))
 		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))


### PR DESCRIPTION
Previously, ExecScript shared a 30m timeout with the status query loop.
Now, it can be specified by the user, or defaults to 5m if it is left
unspecified.

### Related Issues
This is followup from https://github.com/gravitational/robotest/pull/233#discussion_r432104739

### Notes
I'm not aware of *any* current use of the script install parameter. As such I'm tempted to remove the script capability entirely instead of adding ~125 SLOC to support it in a proper fashion.  This would be a breaking change that would require a semver major version bump (maybe merge before 2.0.0?).  The implementation in this PR falls under a minor version bump, as it adds a new configuration parameter for something previously unconfigurable.

### Testing Done
With a 60s script and no timeout specified (thus the default):

```
walt@work:~/git/robotest$ ./cfg/base.sh                                                                                                                                                       
version metadata saved to version.go                                                                                                                                                          
Robotest Version: 2.0.0-alpha.1.18+c14473ad-dirty                                                                                                                                             
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=<redacted> -test.parallel=1 -retries=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0
528-2128/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug
// snip provisioner info                                                                                                                                                             
'install={"nodes":1,"flavor":"one","os":"redhat:7","role":"node","script":{"url":"/tmp/sleep1m.sh"}}'
Type 'help' for list of commands.
(dlv) cont
Command failed: command not available
(dlv) c
INFO[0000] [PROFILING] http localhost:6060               
DEBU[0000] Version:     2.0.0-alpha.1.18+c14473ad-dirty     
DEBU[0000] Git Commit:  c14473adfd4d94e753c9b534d7f0a2722047b66d 
INFO RUNNING                                       commit=c14473adfd4d94e753c9b534d7f0a2722047b66d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22projec
t%22%0Alabels.__uuid__%3D%2207847507-6e11-48f5-94a1-201e7792a848%22%0Alabels.__suite__%3D%22c3612373-8235-416f-8f1a-e6fd6a25115d%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 param="{"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7"},"storage_driver":"","nodes":1,"script":{"url":"/tmp/sleep1m.sh","args":null,"timeout":"5m0s"}}" version="2.0.0-alpha.1.18+c14473ad-dirty" where=[/retry.go:36]
```
[logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-29T04:54:10.830000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2207847507-6e11-48f5-94a1-201e7792a848%22%0Alabels.__suite__%3D%22c3612373-8235-416f-8f1a-e6fd6a25115d%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-29T03:29:35.537Z&interval=PT1H&scrollTimestamp=2020-05-29T04:40:41.725806357Z&dateRangeUnbound=forwardInTime)

With a 60s script and a 30s timeout:
```
walt@work:~/git/robotest$ ./cfg/base.sh                                                                                                                                                       
version metadata saved to version.go                                                                                                                                                          
Robotest Version: 2.0.0-alpha.1.18+c14473ad-dirty                                                                                                                                             
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=redacted -test.parallel=1 -retries=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0
528-2048/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug 
// snip provisioner info
'install={"nodes":1,"flavor":"one","os":"redhat:7","role":"node","script":{"url":"/tmp/sleep1m.sh","timeout":"30s"}}'                                                                       
Type 'help' for list of commands.                                                                                                                                                             
(dlv) c                                                                                                                                                                                       
INFO[0000] [PROFILING] http localhost:6060                                                                                                                                                    
DEBU[0000] Version:     2.0.0-alpha.1.18+c14473ad-dirty                                                                                                                                       
DEBU[0000] Git Commit:  c14473adfd4d94e753c9b534d7f0a2722047b66d                                                                                                                              
INFO RUNNING                                       commit=c14473adfd4d94e753c9b534d7f0a2722047b66d logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22projec
t%22%0Alabels.__uuid__%3D%22885d7fb7-e09b-498c-8a41-bf5414623555%22%0Alabels.__suite__%3D%2284880353-4545-4483-972c-3debd202a4a6%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=ku
beadm-167321" name=walt-install-1 param="{"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7"},"storage_driv
er":"","nodes":1,"script":{"url":"/tmp/sleep1m.sh","args":null,"timeout":"30s"}}" version="2.0.0-alpha.1.18+c14473ad-dirty" where=[/retry.go:36]
```
[logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-05-29T04:29:04.420000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22885d7fb7-e09b-498c-8a41-bf5414623555%22%0Alabels.__suite__%3D%2284880353-4545-4483-972c-3debd202a4a6%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-05-29T03:29:04.993Z&dateRangeEnd=2020-05-29T04:29:04.993Z&interval=PT1H&scrollTimestamp=2020-05-29T04:27:35.065197221Z)

