### PR TITLE
Update README. Add CONTRIBUTING and CODE_OF_CONDUCT.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at info@gravitational.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Robotest
+
+Robotest is an open source project.
+
+Robotest is the work of [many contributors](https://github.com/gravitational/robotest/graphs/contributors).
+We appreciate your help! :tada:
+
+Robotest contributors follow a [code of conduct](./CODE_OF_CONDUCT.md).
+
+Robotest tends to have mostly Gravitational staff as contributors, so
+we're excited to get any outside contributions, including issues.
+
+## Filing an Issue
+
+Security issues should be reported directly to security@gravitational.com.
+
+If you are unsure if you've found a bug, please search Robotest's
+[current issues](https://github.com/gravitational/robotest/issues).
+
+## Contributing A Patch
+
+If you're working on an existing issue, respond to the issue and express
+interest in working on it. This helps other contributors know that the issue is
+active, and hopefully prevents duplicated efforts.
+
+If you want to work on a new idea:
+
+1. Submit an issue describing the proposed change and the implementation.
+2. Robotest maintainers will triage & respond to your issue.
+3. Write your code, test your changes. Run `make lint`, `make test` and `make build`.
+Most importantly,  _communicate_ with the maintainers as you develop.
+4. Submit a pull request from your fork.
+
+# Coding Guidelines
+
+## Adding dependencies
+
+If you wish to add new dependencies (anything that touches `Dockerfile`s or `go.mod`),
+the new dependencies must be:
+
+- licensed via Apache2 license
+- approved by Gravitational staff
+
+## Compatibility & API Stability
+
+Robotest follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+(semver) for its CLI API. Robotest is not intended to be used as a library, and
+makes no guarantees about the stability of any native golang APIs, even if exported.
+
+Due to semver's strict requirements, patches that introduce new options
+or change behavior of the CLI API may need to wait for the next minor or major
+release for merge. Major & minor releases are issued on an as needed basis.
+
+## Style
+
+Robotest follows [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments),
+in alignment with all of Gravitational's go code.  Some (but not all) of the
+guidelines are automated by Robotest's `make lint` target.  Please run
+`make lint` before submitting code to save reviewers the hassle of stylistic
+nits.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# robotest
+# Robotest
 
-`robotest` is a set of integration tests for the gravity platform.
-It is implemented as a testing package that is built as a binary with custom command-line to drive test execution:
+Robotest is a tool for running automated integration tests against [Gravity](https://gravitational.com/gravity).
 
-# Varieties
+# Running
+To learn how to run `robotest-suite`, see the [suite README](./suite/README.md).
 
- - [Browser Based Tests](./e2e/README.md)
- - [CLI based tests](./suite/README.md)
+# Contributing
+If you would like to contribute to Robotest, check out our [contribution guidelines](CONTRIBUTING.md).
+
+# End-to-End Testing (deprecated)
+In earlier versions, Robotest offered automated Web UI based tests against the
+Gravity web installer.  After [significant changes](https://github.com/gravitational/gravity/pull/424/)
+to the Web UI in Gravity 6.0 these browser based tests were never updated and
+have now fallen into disuse.  For more information on browser based tests see
+the [e2e README](./e2e/README.md).


### PR DESCRIPTION
These changes bring robotest in alignment with what Gravity offers and
expects from potential community contributors.

While this isn't specifically release docs, it is some prep work for the
release documentation I'm working on for #200. 

### Testing Done
Eyeballed the changes here:

https://github.com/wadells/robotest/tree/contributing