### PR TITLE
Add a Pull Request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description
+<!-- Required. Provide a concise overview of *why* this change is important. -->
+
+### Risk Profile
+<!-- Required. Remove all but one. Refer to https://semver.org/spec/v2.0.0.html -->
+ - Bug fix (patch release) <!-- An API compatible internal change which fixes incorrect behavior linked in Related Issues. Bug fixes shall include an automated test case that fails without the fix and pass with it. -->
+ - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->
+ - Backwards incompatible change (major release) <!-- This change introduces a change that could or will break existing usage of Robotest's API. -->
+ - Non-product change <!-- This change couldn't possibly affect the Robotest build artifact. Fixing a typo in a comment?  README or documentation changes? Select this. -->
+
+### Related Issues
+<!-- Optional, but highly recommended. Remove this section if unneeded. -->
+
+## Testing Done
+<!-- Required.
+Show the testing you did with shell transcripts, links to logs and/or a mention of the automated test cases that were added. Provide enough information that a co-contributor (or CI system) could reproduce your testing. -->
+<details><summary><code><!-- make test? --></code></summary>
+<pre>
+<!--
+Stub collapsible details provided for convenience.
+Shell transcript goes here.
+-->
+</pre>
+</details>
+
+## Additional Information
+<!-- Optional. Anything else that may be relevant. Remove this section if unneeded. -->


### PR DESCRIPTION
## Description
This will help maintainers & reviewers assess benefit and risk of future pull requests.

### Risk Profile
 - Non-product change <!-- This change couldn't possibly affect the Robotest build artifact. Fixing a typo in a comment?  README or documentation changes? Select this. -->

### Related Issues
Contributes to #200.

## Testing Done
This PR is the testing done. :smile: 

## Additional Information
The template is largely copied from Robotest's Gravity mothership:

  https://github.com/gravitational/gravity/blob/2a15a272262254b49a924fbd51d8b7bd98f60697/.github/pull_request_template.md

However, I've chosen to rework "Type of change" into the semver focused
"Risk Profile" as I want to be crisp about Robotest's versioning. I also
struck TODOs and Implementation as "to process heavy" after observing
how they're used (or not) in Gravity. Furthermore, I made "Related Issues"
optional, as Robotest doesn't see many ports or densely related issues
compared to Gravity.