### PR TITLE
Establish a release process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Required. Provide a concise overview of *why* this change is important. -->
 
 ### Risk Profile
-<!-- Required. Remove all but one. Refer to https://semver.org/spec/v2.0.0.html -->
+<!-- Required. Remove all but one. Refer to https://semver.org/spec/v2.0.0.html and https://github.com/gravitational/robotest/blob/master/RELEASE.md-->
  - Bug fix (patch release) <!-- An API compatible internal change which fixes incorrect behavior linked in Related Issues. Bug fixes shall include an automated test case that fails without the fix and pass with it. -->
  - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->
  - Backwards incompatible change (major release) <!-- This change introduces a change that could or will break existing usage of Robotest's API. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,11 @@ the new dependencies must be:
 
 ## Compatibility & API Stability
 
-Robotest follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
-(semver) for its CLI API. Robotest is not intended to be used as a library, and
-makes no guarantees about the stability of any native golang APIs, even if exported.
+Robotest follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(semver) as described in the [release documentation](./RELEASE.md)
 
 Due to semver's strict requirements, patches that introduce new options
-or change behavior of the CLI API may need to wait for the next minor or major
+or change behavior of the public API may need to wait for the next major or minor
 release for merge. Major & minor releases are issued on an as needed basis.
 
 ## Style

--- a/README.md
+++ b/README.md
@@ -3,7 +3,18 @@
 Robotest is a tool for running automated integration tests against [Gravity](https://gravitational.com/gravity).
 
 # Running
-To learn how to run `robotest-suite`, see the [suite README](./suite/README.md).
+Robotest is distributed as a [Open Container Initiative](https://opencontainers.org/)
+image at https://quay.io/repository/gravitational/robotest-suite.
+
+To learn how to invoke `robotest-suite`, see the [suite README](./suite/README.md).
+
+# Upgrading
+To change to a different version of Robotest, simply depend on a different
+image tag from quay.io.
+
+## API Stability
+See Robotest's [release documentation](./RELEASE.md) for information about
+API stability and backwards compatibility between Robotest versions.
 
 # Contributing
 If you would like to contribute to Robotest, check out our [contribution guidelines](CONTRIBUTING.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,17 +11,114 @@ Named tags (for example `gce-stable`) offer no stability promises and may
 change at any point.
 
 Robotest's command line flags and configuration options logs are
-it's [semver public API](https://semver.org/spec/v2.0.0.html#spec-item-1).
+its [semver public API](https://semver.org/spec/v2.0.0.html#spec-item-1).
 This includes configuration via environment variables in the
 [run_suite.sh](./docker/suite/run_suite.sh) helper script.
 
 Notably: console output, cloud logs, and error messages are not part of
 Robotest's public API and may change in minor releases.
 
-All go APIs (exported or not) are not part of Robotest's public API and may
+All Go APIs (exported or not) are not part of Robotest's public API and may
 change at any time.
 
-These stability guarantees specifically target's Gravity's CI use of Robotest.
+These stability guarantees specifically target Gravity's CI use of Robotest.
 
 Prior to 2.0.0, Robotest broke semver rules, with both new features and
 backwards incompatible changes added as patch releases.  Here be dragons. :dragon:
+
+# Release Instructions
+
+## Prepare
+
+### Select the commit that will become the release.
+
+Checkout the branch/commit that will become the release.
+
+```
+# git checkout master
+```
+
+### Check that changes are within the semver risk profile.
+
+Use `git log` to check that all changes have <= the appropriate risk for the
+planned release bump (major, minor, patch). Each commit in the release should
+be traceable to a PR with the "Risk Profile" filled out.
+
+If this will be the first official release after a one or more
+[pre-release](https://semver.org/spec/v2.0.0.html#spec-item-9) versions (alpha,
+beta, rc, dev), make sure to audit commits back to the prior official
+release.
+
+### Create a new git tag.
+
+Use a `v` prefix for the git tag, to play nicely with
+[golang issue #32945](https://github.com/golang/go/issues/32945). Don't `v`
+prefix the version elsewhere (e.g. tag annotation or release).
+
+Signing is important to make sure the tag (and thus
+release) comes from a known Gravitational maintainer.
+
+For the rest of these instructions `2.0.0` is an example placeholder for
+the version.  Replace 2.0.0 with the actual version you want to release.
+
+```
+$ git tag --sign --message "Robotest 2.0.0" v2.0.0
+```
+
+Run `make version` to double check that the build system correctly picks up
+the tag.
+
+```
+$ make version
+version metadata saved to version.go
+Robotest Version: 2.0.0
+```
+
+### Push the tag to GitHub.
+
+```
+$ git push origin v2.0.0
+Enumerating objects: 1, done.
+Counting objects: 100% (1/1), done.
+Writing objects: 100% (1/1), 807 bytes | 807.00 KiB/s, done.
+Total 1 (delta 0), reused 0 (delta 0)
+To github.com:gravitational/robotest.git
+ * [new tag]         v2.0.0 -> v2.0.0
+```
+
+### Create a draft release in GitHub.
+
+Navigate to https://github.com/gravitational/robotest/releases/tag/v2.0.0
+
+Click Edit Tag. Enter "Robotest 2.0.0" in the "Release Title" field.
+
+Add a concise note about what the release contains in the "Describe this
+release" field.
+
+Click "Save Draft".
+
+## Release
+With all the preperation taken care of, publishing the release will take only
+a minute or two, making the artifacts and release history publicly available.
+
+### Run the "Robotest-publish" Jenkins job.
+
+Navigate to: https://jenkins.gravitational.io/view/Robotest/job/Robotest-publish/
+
+Click "Build with Parameters".
+
+Enter your tag into the "GIT_REF" field, prefixed with "tags/" e.g. `tags/v2.0.0`
+
+Ignore Robotest-publish's TAG parameter. This is unneeded when an annotated
+git tag is used.
+
+Build!
+
+After the build & publish completes successfully verify the new image tag
+is present in https://quay.io/repository/gravitational/robotest-suite.
+
+### Publish the draft GitHub release.
+After the new quay.io artifact is available, publish the draft release
+created earlier in the Prepare step.
+
+Congratulations! Robotest is released!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# Release Documentation
+
+This document contains Robotest's API stability & versioning guarantees
+as well as instructions to help maintainers meet these guarantees and
+ensure consistent releases.
+
+# API Stability
+Robotest follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(semver) for all image tags with a version specifier (for example `2.0.0`).
+Named tags (for example `gce-stable`) offer no stability promises and may
+change at any point.
+
+Robotest's command line flags and configuration options logs are
+it's [semver public API](https://semver.org/spec/v2.0.0.html#spec-item-1).
+This includes configuration via environment variables in the
+[run_suite.sh](./docker/suite/run_suite.sh) helper script.
+
+Notably: console output, cloud logs, and error messages are not part of
+Robotest's public API and may change in minor releases.
+
+All go APIs (exported or not) are not part of Robotest's public API and may
+change at any time.
+
+These stability guarantees specifically target's Gravity's CI use of Robotest.
+
+Prior to 2.0.0, Robotest broke semver rules, with both new features and
+backwards incompatible changes added as patch releases.  Here be dragons. :dragon:


### PR DESCRIPTION
## Description
This PR captures the process I followed for the last two Robotest releases, and formally establishes expectations that the maintainers :

1) assess semver risk when new releases are put out
2) formally tag releases

Before, releasing and backwards compatibility was "best effort" and undocumented, contributing to failures like https://github.com/gravitational/gravity/issues/1508.

### Risk Profile
 - Non-product change <!-- This change couldn't possibly affect the Robotest build artifact. Fixing a typo in a comment?  README or documentation changes? Select this. -->

### Related Issues
Fixes #200.

This documentation should help prevent issues like https://github.com/gravitational/gravity/issues/1508

## Testing Done
I released the following two released following this process:

https://github.com/gravitational/robotest/releases/tag/v2.0.0-rc.1
https://github.com/gravitational/robotest/releases/tag/v2.0.0

I also eyeballed the docs and checked most links at:

https://github.com/wadells/robotest/blob/release-docs/RELEASE.md

## Additional Information
Github releases aren't needed by Gravity (which just depends on quay.io images).  However they're a nice public facing record of the official releases -- as opposed to the various unofficial development builds that get pushed to quay.

Furthermore, I'm hoping that following a process close to Gravity's release process (i.e. GitHub releases) will mean I feel the same pain, and thus am inclined to automate the tedious parts of release process for both Robotest and Gravity.

I chose to put these in the Gravity repo instead of our internal wiki because there was not any particularly sensitive info -- though the Jenkins stuff is clearly useless to those without access.  I prefer to be open about our process unless I have a strong reason otherwise (e.g. security).


