### PR TITLE
Refactor terraform stdout logging.

### DIFF
--- a/infra/terraform/terraform.go
+++ b/infra/terraform/terraform.go
@@ -326,8 +326,6 @@ func (r *terraform) boot(ctx context.Context) (rc io.ReadCloser, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to boot terraform cluster: %s", out)
 	}
-	r.Debug("Cluster outputs:", string(out))
-
 	return ioutil.NopCloser(bytes.NewReader(out)), nil
 }
 
@@ -354,7 +352,7 @@ func (r *terraform) command(ctx context.Context, args []string, opts ...system.C
 		"cmd": cmd,
 		"pid": cmd.Process.Pid,
 	})
-	logger.Info("Command started.")
+	logger.Debug("Command started.")
 	waitDone := make(chan struct{})
 	go func() {
 		select {
@@ -367,8 +365,7 @@ func (r *terraform) command(ctx context.Context, args []string, opts ...system.C
 	close(waitDone)
 	logger.WithFields(log.Fields{
 		log.ErrorKey: err,
-		"output":     out.String(),
-	}).Info("Command finished.")
+	}).Debug("Command finished:\n", out.String()) // out intentionally included in the message, see #244
 	if err != nil {
 		return out.Bytes(), trace.Wrap(err, "command %#v failed: %s", cmd, out.Bytes())
 	}


### PR DESCRIPTION
## Description
In logrus 1.0.3 (PR #237) all log fields started being escaped.  This multiline
terraform stdout was collapsed into a single line, and became quite
unreadable as described in #244.

To counteract this, put the stdout into the log message, instead of one
of the fields.  A bit of a hack, but it keeps console logs a bit more
readable

### Risk Profile
 - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->

Although this "fixes" a regression, it doesn't restore the previous fuctionality exactly, just close enough for everyday uses.  This is more of a "fail forward" approach, as I didn't want to get locked on logrus 1.0.2 for eternity.

### Related Issues
Fixes #244.

## Testing Done
<details><summary>one node install console logs</summary>

<pre>
walt@work:~/git/robotest$ ./cfg/base.sh
version metadata saved to version.go
Robotest Version: 2.1.0-alpha.0.4+f326f689
+ dlv test ./suite -- -test.timeout=1h -gcl-project-id=kubeadm-167321 -test.parallel=1 -retries=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0608-1448/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt -suite=sanity -debug '-provision=
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.5/linux/x86_64/telekube-7.0.5-linux-x86_64.tar
gravity_url: s3://hub.gravitational.io/gravity/oss/bin/gravity/7.0.5/linux/x86_64/gravity-7.0.5-linux-x86_64
// snip
' 'install={"nodes":1,"flavor":"one","os":"redhat:7","role":"node"}'
Type 'help' for list of commands.
(dlv) c
INFO[0000] [PROFILING] http localhost:6060/
DEBU[0000] Version:     2.1.0-alpha.0.4+f326f689
DEBU[0000] Git Commit:  f326f689791bce8000724ab3a5fa10fda0785fa3
INFO RUNNING                                       commit=f326f689791bce8000724ab3a5fa10fda0785fa3 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 param="{\"role\":\"node\",\"cluster\":\"\",\"flavor\":\"one\",\"remote_support\":false,\"state_dir\":\"/var/lib/gravity\",\"os\":{\"Vendor\":\"redhat\",\"Version\":\"7\"},\"storage_driver\":\"\",\"nodes\":1,\"script\":null}" version=2.1.0-alpha.0.4+f326f689 where="[/retry.go:37]"
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap/centos.sh -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap/centos.sh
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap/debian.sh -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap/debian.sh
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap/redhat.sh -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap/redhat.sh
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap/suse.sh -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap/suse.sh
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/bootstrap/ubuntu.sh -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/bootstrap/ubuntu.sh
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/config.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/config.tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/network.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/network.tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/node.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/node.tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/os.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/os.tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/output.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/output.tf
DEBU[0000] copy /home/walt/git/robotest/assets/terraform/gce/versions.tf -> /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/versions.tf
DEBU[0000] Command started.                              cluster= cmd="/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf" pid=809044 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0000] Command finished:

Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.  cluster= cmd="/home/walt/.local/bin/terraform init -input=false -get-plugins=false -plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf" error="<nil>" pid=809044 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0000] map[credentials:/home/walt/git/robotest/kubeadm-167321-2d663815917d.json node_tag:robotest-798c3ec8 nodes:1 os:redhat:7 os_user:redhat region:us-west1 ssh_pub_key_path:/home/walt/.ssh/robotest.pub vm_type:custom-8-8192]
DEBU[0000] Command started.                              cluster= cmd="/home/walt/.local/bin/terraform apply -input=false -auto-approve -var-file=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/robotest.tfvars.json -var-file=/home/walt/git/robotest/logs/0608-1448/gcp-vars.json" pid=809069 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0020] Command finished:
data.template_file.bootstrap: Refreshing state...
data.google_compute_network.robotest: Refreshing state...
data.google_compute_subnetwork.robotest: Refreshing state...
data.google_compute_zones.available: Refreshing state...
random_shuffle.zones: Creating...
random_shuffle.zones: Creation complete after 0s [id=-]
google_compute_disk.etcd[0]: Creating...
google_compute_disk.boot[0]: Creating...
google_compute_disk.etcd[0]: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-etcd-0]
google_compute_disk.boot[0]: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-boot-0]
google_compute_instance.node[0]: Creating...
google_compute_instance.node[0]: Creation complete after 9s [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0]
google_compute_instance_group.robotest: Creating...
google_compute_instance_group.robotest: Creation complete after 4s [id=projects/kubeadm-167321/zones/us-west1-a/instanceGroups/robotest-798c3ec8-node-group]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

private_ips = [
  "10.138.0.6",
]
public_ips = [
  "35.233.251.14",
]  cluster= cmd="/home/walt/.local/bin/terraform apply -input=false -auto-approve -var-file=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/robotest.tfvars.json -var-file=/home/walt/git/robotest/logs/0608-1448/gcp-vars.json" error="<nil>" pid=809069 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0020] Command started.                              cluster= cmd="/home/walt/.local/bin/terraform output -json" pid=809334 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0020] Command finished:
{
  "private_ips": {
    "sensitive": false,
    "type": [
      "tuple",
      [
        "string"
      ]
    ],
    "value": [
      "10.138.0.6"
    ]
  },
  "public_ips": {
    "sensitive": false,
    "type": [
      "tuple",
      [
        "string"
      ]
    ],
    "value": [
      "35.233.251.14"
    ]
  }
}  cluster= cmd="/home/walt/.local/bin/terraform output -json" error="<nil>" pid=809334 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0020] Cluster: node(addr=35.233.251.14).            cluster= plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0033] test /var/lib/bootstrap_complete -f false retry in 5s  timeout-in=29m47.182066085s
DEBU[0038] test /var/lib/bootstrap_complete -f false retry in 5s  timeout-in=29m42.088900391s
DEBU[0048] test /var/lib/bootstrap_complete -f false retry in 5s  timeout-in=29m31.987227581s
DEBU[0068] test /var/lib/bootstrap_complete -f false retry in 5s  timeout-in=29m11.894880268s
DEBU[0108] succeded
INFO VMs ready                                     elapsed=1m47.787145999s logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/suite/sanity/install.go:78]"
INFO Transfer installer s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.5/linux/x86_64/telekube-7.0.5-linux-x86_64.tar -> /home/redhat/install.  installer_dir=/home/redhat/install installer_url="s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.5/linux/x86_64/telekube-7.0.5-linux-x86_64.tar" ip=10.138.0.6 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 public_ip=35.233.251.14 where="[/infra/gravity/node_commands.go:462]"
INFO installer downloaded                          elapsed=54.520851769s logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/suite/sanity/install.go:88]"
INFO Offline install.                              logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/infra/gravity/cluster_install.go:68]"
INFO Install on leader node.                       logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node="node(private_addr=10.138.0.6, public_addr=35.233.251.14)" node_tag=robotest-798c3ec8 where="[/infra/gravity/cluster_install.go:87]"
INFO application installed                         elapsed=5m52.688271945s logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/suite/sanity/install.go:93]"
INFO Waiting for active status.                    logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 nodes="node(private_addr=10.138.0.6, public_addr=35.233.251.14)" where="[/infra/gravity/cluster_status.go:45]"
INFO wait for active status                        elapsed=1.251298007s logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/suite/sanity/install.go:94]"
INFO Logs saved.                                   ip=10.138.0.6 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 path=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/node-logs/postmortem/10.138.0.6-logs.tgz public_ip=35.233.251.14 where="[/infra/gravity/cluster_status.go:163]"
INFO Destroying VMs.                               logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 nodes="[node(private_addr=10.138.0.6, public_addr=35.233.251.14)]" provisioner_policy="{true true true /home/walt/git/robotest/logs/0608-1448/alloc.txt}" test_status=ok where="[/infra/gravity/terraform.go:97]"
DEBU[0552] Destroying terraform cluster: /home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf.  cluster= plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0552] Command started.                              cluster= cmd="/home/walt/.local/bin/terraform destroy -auto-approve -var-file=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/robotest.tfvars.json -var-file=/home/walt/git/robotest/logs/0608-1448/gcp-vars.json" pid=809467 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
DEBU[0598] Command finished:
data.template_file.bootstrap: Refreshing state...
data.google_compute_network.robotest: Refreshing state...
data.google_compute_subnetwork.robotest: Refreshing state...
data.google_compute_zones.available: Refreshing state...
random_shuffle.zones: Refreshing state... [id=-]
google_compute_disk.etcd[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-etcd-0]
google_compute_disk.boot[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-boot-0]
google_compute_instance.node[0]: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0]
google_compute_instance_group.robotest: Refreshing state... [id=projects/kubeadm-167321/zones/us-west1-a/instanceGroups/robotest-798c3ec8-node-group]
google_compute_instance_group.robotest: Destroying... [id=projects/kubeadm-167321/zones/us-west1-a/instanceGroups/robotest-798c3ec8-node-group]
google_compute_instance_group.robotest: Destruction complete after 3s
google_compute_instance.node[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0, 10s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0, 20s elapsed]
google_compute_instance.node[0]: Still destroying... [id=projects/kubeadm-167321/zones/us-west1-a/instances/robotest-798c3ec8-node-0, 30s elapsed]
google_compute_instance.node[0]: Destruction complete after 36s
google_compute_disk.etcd[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-etcd-0]
google_compute_disk.boot[0]: Destroying... [id=projects/kubeadm-167321/zones/us-west1-a/disks/robotest-798c3ec8-disk-boot-0]
google_compute_disk.boot[0]: Destruction complete after 1s
google_compute_disk.etcd[0]: Destruction complete after 4s
random_shuffle.zones: Destroying... [id=-]
random_shuffle.zones: Destruction complete after 0s

Destroy complete! Resources: 5 destroyed.  cluster= cmd="/home/walt/.local/bin/terraform destroy -auto-approve -var-file=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf/robotest.tfvars.json -var-file=/home/walt/git/robotest/logs/0608-1448/gcp-vars.json" error="<nil>" pid=809467 plugin-dir=/home/walt/.terraform.d/plugins/linux_amd64 provisioner=terraform state-dir=/home/walt/git/robotest/logs/0608-1448/walt/install-1/redhat7/none/1n/tf
INFO destroy                                       elapsed=1m22.053863936s logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 where="[/suite/sanity/install.go:80]"
INFO PASSED                                        commit=f326f689791bce8000724ab3a5fa10fda0785fa3 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 param="{\"role\":\"node\",\"cluster\":\"\",\"flavor\":\"one\",\"remote_support\":false,\"state_dir\":\"/var/lib/gravity\",\"os\":{\"Vendor\":\"redhat\",\"Version\":\"7\"},\"storage_driver\":\"\",\"nodes\":1,\"script\":null}" version=2.1.0-alpha.0.4+f326f689 where="[]"
INFO BQ SAVE                                       commit=f326f689791bce8000724ab3a5fa10fda0785fa3 data="map[name:walt-install-1 nodes:1 os:redhat os_version:7 status:PASSED storage: suite:eb995975-c01f-46ce-9e4c-11b94513f0ea ts:2020-06-08 14:58:09.976404374 -0700 PDT m=+598.981198494 uuid:a4449a89-fa06-446a-b4e4-2e34614f31e9]" logs="https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321" name=walt-install-1 node_tag=robotest-798c3ec8 param="{\"role\":\"node\",\"cluster\":\"\",\"flavor\":\"one\",\"remote_support\":false,\"state_dir\":\"/var/lib/gravity\",\"os\":{\"Vendor\":\"redhat\",\"Version\":\"7\"},\"storage_driver\":\"\",\"nodes\":1,\"script\":null}" version=2.1.0-alpha.0.4+f326f689 where="[]"

******** TEST SUITE COMPLETED **********
PASSED walt-install-1 {"role":"node","cluster":"","flavor":"one","remote_support":false,"state_dir":"/var/lib/gravity","os":{"Vendor":"redhat","Version":"7"},"storage_driver":"","nodes":1,"script":null} https://console.cloud.google.com/logs/viewer?advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%22a4449a89-fa06-446a-b4e4-2e34614f31e9%22%0Alabels.__suite__%3D%22eb995975-c01f-46ce-9e4c-11b94513f0ea%22%0Aseverity%3E%3DINFO&authuser=1&expandAll=false&project=kubeadm-167321
PASS
Process 809026 has exited with status 0
(dlv) exit
</pre>
</details>
