### PR TITLE
Add a semantic newline to <details> in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@
 <!-- Required.
 Show the testing you did with shell transcripts, links to logs and/or a mention of the automated test cases that were added. Provide enough information that a co-contributor (or CI system) could reproduce your testing. -->
 <details><summary><code><!-- make test? --></code></summary>
+
 <pre>
 <!--
 Stub collapsible details provided for convenience.


### PR DESCRIPTION
## Description
As discussed at:

  https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab

GitHub flavored markdown requires a blank line after the summary tag
closes before it will properly start interpreting other html or
markdown.  Without this, `<p>` tags are injected into the `<pre>` block.

### Risk Profile
 - Non-product change <!-- This change couldn't possibly affect the Robotest build artifact. Fixing a typo in a comment?  README or documentation changes? Select this. -->

### Related Issues
Fixes a display bug from #239 

## Testing Done
<details><summary>without the space</summary>
<pre>
walt@work:~/git/robotest$ git status
On branch pr-template-fix
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .github/pull_request_template.md

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        foo
</pre>
</details>

<details><summary>with the space</summary>

<pre>
walt@work:~/git/robotest$ git status
On branch pr-template-fix
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   .github/pull_request_template.md

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        foo
</pre>
</details>

## Additional Information
Sending to @bernardjkim for review, as this is a quick and easy one and I've been sending a lot to Roman & Dmitri.