### PR TITLE
Bootstrap script SUSE 15 support

### DIFF
--- a/assets/terraform/gce/bootstrap/suse.sh
+++ b/assets/terraform/gce/bootstrap/suse.sh
@@ -81,8 +81,23 @@ mkdir -p $etcd_dir /var/lib/data
 secure-ssh
 setup-user
 
-curl https://bootstrap.pypa.io/get-pip.py | python -
-pip install --upgrade awscli
+function install-aws-cli {
+  # suse-cloud/sles-15-sp1-v20200415 has no python, but offers python3.
+  # suse-cloud/sles-12-sp5-v20200227 has both, but it's python3 < 3.5 and is
+  # incompatible with awscli.
+  if command -v python; then
+    local python=$(command -v  python)
+  elif command -v python3; then
+    local python=$(command -v python3)
+  else
+    echo "No python available."
+    exit 2
+  fi
+  curl https://bootstrap.pypa.io/get-pip.py | $python -
+  pip install --upgrade awscli
+}
+
+install-aws-cli
 
 mkdir -p /var/lib/gravity/planet/etcd /var/lib/data
 

--- a/assets/terraform/gce/config.tf
+++ b/assets/terraform/gce/config.tf
@@ -98,4 +98,3 @@ resource "random_shuffle" "zones" {
 locals {
   zone = random_shuffle.zones.result[0]
 }
-

--- a/assets/terraform/gce/node.tf
+++ b/assets/terraform/gce/node.tf
@@ -100,12 +100,16 @@ resource "google_compute_instance" "node" {
   }
 }
 
+locals {
+  boot_disk_size = 64
+}
+
 resource "google_compute_disk" "boot" {
   count = var.nodes
   name  = "${var.node_tag}-disk-boot-${count.index}"
   type  = var.disk_type
   zone  = local.zone
-  size  = 64
+  size  = local.boot_disk_size
   image = var.oss[var.os]
 
   labels = {
@@ -131,8 +135,10 @@ data "template_file" "bootstrap" {
   template = file("./bootstrap/${element(split(":", var.os), 0)}.sh")
 
   vars = {
-    os_user     = var.os_user
-    ssh_pub_key = file(var.ssh_pub_key_path)
+    os_user             = var.os_user
+    ssh_pub_key         = file(var.ssh_pub_key_path)
+    # 1G left for other partions (e.g. efi)
+    root_partition_size = local.boot_disk_size - 1
   }
 }
 


### PR DESCRIPTION
## Description
This PR includes necessary changes to run robotest against SUSE 15 sp1.

Although gravity doesn't support this distribution yet, this work will come in handy when we want to add SUSE 15 support to Gravity (and thus validate it with robotest).

See the individual commit messages for more context on the two changes.

### Risk Profile
 - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->

### Related Issues
Contributes to #248 and gravitational/gravity#1582.

## Testing Done
Logs [here](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-06-15T18:25:05.442000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%2227d33712-3515-48a6-835e-c51dbf8d8091%22%0Alabels.__suite__%3D%22afa7468d-fd1b-4f43-8ace-206e2f28d4dd%22&dateRangeStart=2020-06-15T17:25:14.361Z&dateRangeEnd=2020-06-15T18:25:14.361Z&interval=PT1H&scrollTimestamp=2020-06-15T18:24:49.763516164Z). This run failed, but it is an expected failure:

```
The following pre-flight checks failed: [×] sles 15.1 is not supported
```

I will get a SUSE 12 run (to make sure it didn't regress) before merging.
