### PR TITLE
Refactor InstallerURL config passing.

### DIFF
--- a/suite/sanity/install.go
+++ b/suite/sanity/install.go
@@ -96,12 +96,7 @@ func install(p interface{}) (gravity.TestFunc, error) {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		installerURL := cfg.InstallerURL
-		if param.InstallerURL != "" {
-			installerURL = param.InstallerURL
-		}
-
-		g.OK("installer downloaded", g.SetInstaller(cluster.Nodes, installerURL, "install"))
+		g.OK("installer downloaded", g.SetInstaller(cluster.Nodes, param.InstallerURL, "install"))
 		if param.Script != nil {
 			g.OK("post bootstrap script",
 				g.ExecScript(cluster.Nodes, param.Script.Url, param.Script.Args, param.Script.Timeout.Duration))
@@ -121,11 +116,6 @@ func provision(p interface{}) (gravity.TestFunc, error) {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		installerURL := cfg.InstallerURL
-		if param.InstallerURL != "" {
-			installerURL = param.InstallerURL
-		}
-
-		g.OK("download installer", g.SetInstaller(cluster.Nodes, installerURL, "install"))
+		g.OK("download installer", g.SetInstaller(cluster.Nodes, param.InstallerURL, "install"))
 	}, nil
 }

--- a/suite/sanity/loss_recover.go
+++ b/suite/sanity/loss_recover.go
@@ -96,7 +96,7 @@ func lossAndRecovery(p interface{}) (gravity.TestFunc, error) {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		g.OK("download installer", g.SetInstaller(cluster.Nodes, cfg.InstallerURL, "install"))
+		g.OK("download installer", g.SetInstaller(cluster.Nodes, param.InstallerURL, "install"))
 
 		nodes := cluster.Nodes[0:param.NodeCount]
 		g.OK("install", g.OfflineInstall(nodes, param.InstallParam))

--- a/suite/sanity/resize.go
+++ b/suite/sanity/resize.go
@@ -54,7 +54,7 @@ func resize(p interface{}) (gravity.TestFunc, error) {
 			g.Maybe("destroy", cluster.Destroy())
 		}()
 
-		g.OK("download installer", g.SetInstaller(cluster.Nodes, cfg.InstallerURL, "install"))
+		g.OK("download installer", g.SetInstaller(cluster.Nodes, param.InstallerURL, "install"))
 		g.OK(fmt.Sprintf("install on %d node", param.NodeCount),
 			g.OfflineInstall(cluster.Nodes[:param.NodeCount], param.InstallParam))
 		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes[:param.NodeCount]))

--- a/suite/sanity/sanity.go
+++ b/suite/sanity/sanity.go
@@ -22,15 +22,16 @@ import (
 	"github.com/gravitational/robotest/lib/defaults"
 )
 
-var defaultInstallParam = installParam{
-	InstallParam: gravity.InstallParam{
-		StateDir: defaults.GravityDir,
-	},
-}
-
 // Suite returns base configuration for a suite which may be further customized
-func Suite() *config.Config {
+func Suite(provisionerConfig gravity.ProvisionerConfig) *config.Config {
 	cfg := config.New()
+
+	defaultInstallParam := installParam{
+		InstallParam: gravity.InstallParam{
+			InstallerURL: provisionerConfig.InstallerURL,
+			StateDir:     defaults.GravityDir,
+		},
+	}
 
 	cfg.Add("noop", noop, noopParam{})
 	cfg.Add("noopV", noopVariety, noopParam{})
@@ -40,7 +41,7 @@ func Suite() *config.Config {
 	cfg.Add("recover", lossAndRecovery, lossAndRecoveryParam{installParam: defaultInstallParam})
 	cfg.Add("recoverV", lossAndRecoveryVariety, defaultInstallParam)
 	cfg.Add("shrink", shrink, defaultInstallParam)
-	cfg.Add("upgrade", upgrade, upgradeParam{installParam: defaultInstallParam})
+	cfg.Add("upgrade", upgrade, upgradeParam{installParam: defaultInstallParam, GravityURL: provisionerConfig.GravityURL})
 	// upgrade3lts is vestigial alias for upgrade needed for backwards compat
 	// to prevent issues like:
 	//   https://github.com/gravitational/gravity/issues/1508

--- a/suite/sanity/shrink.go
+++ b/suite/sanity/shrink.go
@@ -42,7 +42,7 @@ func shrink(p interface{}) (gravity.TestFunc, error) {
 		copy(others, cluster.Nodes[1:])
 		g.Logger().WithFields(logrus.Fields{"target": target, "others": others}).Info("Select join/shrink target.")
 
-		g.OK("Download installer.", g.SetInstaller(all, cfg.InstallerURL, "install"))
+		g.OK("Download installer.", g.SetInstaller(all, param.InstallerURL, "install"))
 
 		g.OK("Install.", g.OfflineInstall(others, param.InstallParam))
 		g.OK("Wait for active status.", g.WaitForActiveStatus(others))

--- a/suite/sanity/upgrade.go
+++ b/suite/sanity/upgrade.go
@@ -27,6 +27,7 @@ type upgradeParam struct {
 	installParam
 	// BaseInstallerURL is initial app installer URL
 	BaseInstallerURL string `json:"from" validate:"required"`
+	GravityURL       string `json:"gravity_url"`
 }
 
 func (p upgradeParam) Save() (row map[string]bigquery.Value, insertID string, err error) {
@@ -52,7 +53,7 @@ func upgrade(p interface{}) (gravity.TestFunc, error) {
 		g.OK("base installer", g.SetInstaller(cluster.Nodes, param.BaseInstallerURL, "base"))
 		g.OK("install", g.OfflineInstall(cluster.Nodes, param.InstallParam))
 		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))
-		g.OK("upgrade", g.Upgrade(cluster.Nodes, cfg.InstallerURL, cfg.GravityURL, "upgrade"))
+		g.OK("upgrade", g.Upgrade(cluster.Nodes, param.InstallerURL, param.GravityURL, "upgrade"))
 		g.OK("wait for active status", g.WaitForActiveStatus(cluster.Nodes))
 	}, nil
 }


### PR DESCRIPTION
## Description
In order to accommodate unique installers on a per test basis always treat the `InstallerURL` from the provisioner as the default and override it when `installer_url` is specified in the test parameter JSON. This was previously available for the install test, but is now available for all tests in the sanity suite.



### Risk Profile
 - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->

### Related Issues
This is needed to spit the images between upgrade and all other testing
for incremental rollout of new robotest images:
* https://github.com/gravitational/gravity/issues/1908
* https://github.com/gravitational/gravity/issues/1915

## Testing Done
<details><summary>install without overide</summary>

```
walt@work:~/git/robotest$ dlv test ./suite -- -test.timeout=1h -gcl-project-id=redacted -test.parallel=1 -retries=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0809-2222/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt-base -suite=sanity -debug '-provision=                                                                         
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/5.2.16/linux/x86_64/telekube-5.2.16-linux-x86_64.tar                                                                        
gravity_url: s3://hub.gravitational.io/gravity/oss/bin/gravity/5.2.16/linux/x86_64/gravity-5.2.16-linux-x86_64                                                                                
script_path: /home/walt/git/robotest/assets/terraform/gce                                                                                                                                     tf_plugin_dir: /home/walt/.terraform.d/plugins/linux_amd64                                                                                                                                    state_dir: /home/walt/git/robotest/logs/0809-2222                                                                                                                                             cloud: gce                                                                                                                                                                                    
aws:                                                                                                                                                                                          
  access_key: redacted                                                                                                                                                            
  secret_key: redacted                                                                                                                                      
  region: us-east-1                                                                                                                                                                           
  ssh_user: unused
  key_path: unused
  key_pair: unused
  docker_device: unused
  vpc: unused
gce:
  credentials: redacted
  vm_type: custom-8-8192
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1
  ssh_key_path: /home/walt/.ssh/robotest
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub
  var_file_path: /home/walt/git/robotest/logs/0809-2222/gcp-vars.json
' 'install={"nodes":1,"flavor":"one","os":"redhat:7","role":"node"}'

```

resulted in this run: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-08-10T05:35:15.591000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-08-10T04:35:10.640Z&interval=PT1H&scrollTimestamp=2020-08-10T05:32:40.678596577Z&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%228d02c700-f8b1-41c3-ac52-6c408c5b56a7%22%0Alabels.__suite__%3D%22ca83e4a3-1daf-42a8-b0ae-733bb78ddd78%22%0Aseverity%3E%3DINFO&dateRangeUnbound=forwardInTime)
</details>

<details><summary>install with overide</summary>

```
walt@work:~/git/robotest$ dlv test ./suite -- -test.timeout=1h -gcl-project-id=redacted -test.parallel=1 -retries=1 -fail-fast=true -always-collect-logs=true -resourcegroup-file=/home/walt/git/robotest/logs/0
809-2234/alloc.txt -destroy-on-success=true -destroy-on-failure=true -tag=walt-base -suite=sanity -debug '-provision=                                                                         
installer_url: s3://hub.gravitational.io/gravity/oss/app/telekube/5.2.16/linux/x86_64/telekube-5.2.16-linux-x86_64.tar                                                                        
gravity_url: s3://hub.gravitational.io/gravity/oss/bin/gravity/5.2.16/linux/x86_64/gravity-5.2.16-linux-x86_64                                                                                
script_path: /home/walt/git/robotest/assets/terraform/gce                                                                                                                                     
tf_plugin_dir: /home/walt/.terraform.d/plugins/linux_amd64                                                                                                                                    
state_dir: /home/walt/git/robotest/logs/0809-2234                                                                                                                                             
cloud: gce                                                                                                                                                                                    
aws:                                                                                           
  access_key: redacted                                                                                                                                                            
  secret_key: redacted                                                                                                                                  
  region: us-east-1                                                                                                                                                                           
  ssh_user: unused                                                                                                                                                                            
  key_path: unused                                                                                                                                                                            
  key_pair: unused                                                                                                                                                                            
  docker_device: unused                                                                                                                                                                       
  vpc: unused                                                                                                                                                                                 
gce:                                                                                                                                                                                          
  credentials: redacted                                                                                                            
  vm_type: custom-8-8192                                                                                                                                                                      
  region: northamerica-northeast1,us-west1,us-west2,us-east1,us-east4,us-central1                                                                                                             
  ssh_key_path: /home/walt/.ssh/robotest                                                                                                                                                      
  ssh_pub_key_path: /home/walt/.ssh/robotest.pub                                                                                                                                              
  var_file_path: /home/walt/git/robotest/logs/0809-2234/gcp-vars.json                                                                                                                         
' 'install={"nodes":1,"flavor":"one","os":"redhat:7","role":"node", "installer_url": "s3://hub.gravitational.io/gravity/oss/app/telekube/7.0.13/linux/x86_64/telekube-7.0.13-linux-x86_64.tar"}'  
```

resulted in this run: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-08-10T05:59:21.367000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%222986ead6-bd72-4dd7-84e0-c045b37128a4%22%0Alabels.__suite__%3D%22959f45b5-2887-4324-9acb-3e94312c658c%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-08-10T04:36:45.242Z&interval=PT1H&scrollTimestamp=2020-08-10T05:36:26.753189831Z&dateRangeUnbound=forwardInTime)
</details>

I'll update with a upgrade (for GravityURL) and full run before merging.  I need release a custom testing tag and integrate with gravity to get this.

## Additional Information
The config passing in robotest is a bit wonky.  I'd prefer to remove InstallerURL from `gravity.ProvisionerConfig` entirely because no active codepaths use that value, but unused e2e code depends on an [older implementation](https://github.com/gravitational/robotest/blob/cc85775c920564666e11d914138bbb330d66ff05/infra/terraform/terraform.go#L266-L284). Addressing this requires more holistic cleanup that would move this change into "breaks backwards compatibility" territory and thus a major version bump.