### PR TITLE
Properly parse Gravity 5.0.36 status

### DIFF
--- a/infra/gravity/gravity_test.go
+++ b/infra/gravity/gravity_test.go
@@ -19,9 +19,11 @@ package gravity
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
+	"github.com/gravitational/robotest/lib/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -147,5 +149,46 @@ func TestGravity5036DegradedStatusValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = checkNotDegraded(status)
+	assert.Error(t, err)
+}
+
+func TestSystemStatusStringDegradedUnmarshal(t *testing.T) {
+	input := json.RawMessage(`"degraded"`)
+	expected := constants.SystemStatus_Degraded
+	var status int
+	err := unmarshalSystemStatus(input, &status)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+}
+
+func TestSystemStatusStringRunningUnmarshal(t *testing.T) {
+	input := json.RawMessage(`"running"`)
+	expected := constants.SystemStatus_Running
+	var status int
+	err := unmarshalSystemStatus(input, &status)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+}
+
+func TestSystemStatusIntUnmarshal(t *testing.T) {
+	input := json.RawMessage(`2`)
+	expected := constants.SystemStatus_Degraded
+	var status int
+	err := unmarshalSystemStatus(input, &status)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, status)
+}
+
+func TestSystemStatusInvalidFloatUnmarshal(t *testing.T) {
+	input := json.RawMessage(`3.14159`)
+	var status int
+	err := unmarshalSystemStatus(input, &status)
+	assert.Error(t, err)
+}
+
+func TestSystemStatusInvalidStringUnmarshal(t *testing.T) {
+	input := json.RawMessage(`"working perfectly"`)
+	var status int
+	err := unmarshalSystemStatus(input, &status)
 	assert.Error(t, err)
 }

--- a/infra/gravity/gravity_test.go
+++ b/infra/gravity/gravity_test.go
@@ -109,3 +109,43 @@ func Test1641StatusValidation(t *testing.T) {
 	err = checkNotDegraded(status)
 	assert.Error(t, err)
 }
+
+// TestGravity5036ActiveStatusValidation ensures Robotest can correctly parse
+// an Active status from Gravity 5.0.36.
+//
+// This is important for testing --upgrade-via 5.0.x to 5.2.x to 5.5.x as well
+// as upgrade testing from stolon-app 1.10.x.
+//
+// See https://github.com/gravitational/robotest/issues/247 for more info.
+func TestGravity5036ActiveStatusValidation(t *testing.T) {
+	f, err := os.Open("testdata/status-active-5.0.36.json")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	var status GravityStatus
+	err = parseStatus(&status)(bufio.NewReader(f))
+	assert.NoError(t, err)
+
+	err = checkNotDegraded(status)
+	assert.NoError(t, err)
+}
+
+// TestGravity5036DegradedStatusValidation ensures Robotest can correctly parse
+// a Degraded status from Gravity 5.0.36.
+//
+// This is important for testing --upgrade-via 5.0.x to 5.2.x to 5.5.x as well
+// as upgrade testing from stolon-app 1.10.x.
+//
+// See https://github.com/gravitational/robotest/issues/247 for more info.
+func TestGravity5036DegradedStatusValidation(t *testing.T) {
+	f, err := os.Open("testdata/status-degraded-5.0.36.json")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	var status GravityStatus
+	err = parseStatus(&status)(bufio.NewReader(f))
+	assert.NoError(t, err)
+
+	err = checkNotDegraded(status)
+	assert.Error(t, err)
+}

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -156,7 +156,7 @@ type ClusterStatus struct {
 	// State is the cluster state
 	State string `json:"state"`
 	// SystemStatus is the cluster status, custom unmarshalling logic needed to accommodate Gravity differences
-	SystemStatus int
+	SystemStatus int `json:"-"`
 	// Token is secure token which prevents rogue nodes from joining the cluster during installation
 	Token Token `json:"token"`
 	// Nodes describes the nodes in the cluster

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -170,19 +170,21 @@ type ClusterStatus struct {
 //   https://github.com/gravitational/satellite/blob/5.0.2/agent/proto/agentpb/agent.pb.go#L48-L63
 func unmarshalSystemStatus(val json.RawMessage, status *int) error {
 	err := json.Unmarshal(val, &status)
-	if err != nil { // parsing as int failed, try parsing as a string and converting
-		var str string
-		if err2 := json.Unmarshal(val, &str); err2 != nil {
-			return trace.BadParameter("unable to parse system_status %q as int or string: %v, %v", val, err, err2)
-		}
-		switch str {
-		case "running":
-			*status = constants.SystemStatus_Running
-		case "degraded":
-			*status = constants.SystemStatus_Degraded
-		default:
-			return trace.BadParameter("unknown system_status: %q", str)
-		}
+	if err == nil {
+		return nil
+	}
+	// parsing as int failed, try parsing as a string and converting
+	var str string
+	if err2 := json.Unmarshal(val, &str); err2 != nil {
+		return trace.BadParameter("unable to parse system_status %q as int or string: %v, %v", val, err, err2)
+	}
+	switch str {
+	case "running":
+		*status = constants.SystemStatus_Running
+	case "degraded":
+		*status = constants.SystemStatus_Degraded
+	default:
+		return trace.BadParameter("unknown system_status: %q", str)
 	}
 	return nil
 }

--- a/infra/gravity/node_commands.go
+++ b/infra/gravity/node_commands.go
@@ -155,12 +155,77 @@ type ClusterStatus struct {
 	Cluster string `json:"domain"`
 	// State is the cluster state
 	State string `json:"state"`
-	// SystemStatus is the cluster status, see https://github.com/gravitational/satellite/blob/7.1.0/agent/proto/agentpb/agent.proto#L50-L54
-	SystemStatus int `json:"system_status"`
+	// SystemStatus is the cluster status, custom unmarshalling logic needed to accommodate Gravity differences
+	SystemStatus int
 	// Token is secure token which prevents rogue nodes from joining the cluster during installation
 	Token Token `json:"token"`
 	// Nodes describes the nodes in the cluster
 	Nodes []NodeStatus `json:"nodes"`
+}
+
+// unmarshalSystemStatus is a helper type to parse string or integer system statuses.
+//
+// For the original definitions and mappings see:
+//   https://github.com/gravitational/satellite/blob/5.0.2/agent/proto/agentpb/agent.proto#L36-L40
+//   https://github.com/gravitational/satellite/blob/5.0.2/agent/proto/agentpb/agent.pb.go#L48-L63
+func unmarshalSystemStatus(val json.RawMessage, status *int) error {
+	err := json.Unmarshal(val, &status)
+	if err != nil { // parsing as int failed, try parsing as a string and converting
+		var str string
+		if err2 := json.Unmarshal(val, &str); err2 != nil {
+			return trace.BadParameter("unable to parse system_status %q as int or string: %v, %v", val, err, err2)
+		}
+		switch str {
+		case "running":
+			*status = constants.SystemStatus_Running
+		case "degraded":
+			*status = constants.SystemStatus_Degraded
+		default:
+			return trace.BadParameter("unknown system_status: %q", str)
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON fufills the Unmarshaler interface, allowing ClusterStatus
+// to perform custom JSON unmarshalling for certain fields.
+//
+// This is needed for the system_status field which Gravity 5.2.x+ marshals as
+// an integer and Gravity 5.0.36- marshals as a string. When Gravity 5.0.x
+// support is no longer needed, this function and unmarshalSystemStatus can be
+// removed and replaced by the following field tag in the Cluster status type
+// definition:
+//
+//   SystemStatus int `json:"system_status"`
+//
+// See https://github.com/gravitational/robotest/issues/247 for more info.
+func (cs *ClusterStatus) UnmarshalJSON(data []byte) error {
+	// First, populate all fields that don't require special handling,
+	type recursionBreaker ClusterStatus
+	var temp recursionBreaker
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return trace.Wrap(err)
+	}
+	*cs = ClusterStatus(temp)
+
+	// handle system_status, which may be a string or an int
+	var jsonMap map[string]*json.RawMessage
+	if err := json.Unmarshal(data, &jsonMap); err != nil {
+		return trace.Wrap(err)
+	}
+
+	val, ok := jsonMap["system_status"]
+	if !ok {
+		return trace.BadParameter("system_status field is required: %v", data)
+	}
+
+	var status int
+	if err := unmarshalSystemStatus(*val, &status); err != nil {
+		return trace.Wrap(err)
+	}
+
+	cs.SystemStatus = status
+	return nil
 }
 
 // Application defines the cluster application

--- a/infra/gravity/testdata/status-active-5.0.36.json
+++ b/infra/gravity/testdata/status-active-5.0.36.json
@@ -1,0 +1,41 @@
+{
+  "cluster": {
+    "application": {
+      "repository": "gravitational.io",
+      "name": "telekube",
+      "version": "5.0.36"
+    },
+    "state": "active",
+    "domain": "robotest-unit-test",
+    "token": {
+      "token": "ROBOTEST",
+      "expires": "0001-01-01T00:00:00Z",
+      "type": "expand",
+      "account_id": "00000000-0000-0000-0000-000000000001",
+      "site_domain": "robotest-unit-test",
+      "operation_id": "",
+      "user_email": "agent@robotest-unit-test"
+    },
+    "operation": {
+      "type": "operation_install",
+      "id": "6eb72cb8-56e6-4df4-a3f3-e971a4c64b80",
+      "state": "completed",
+      "created": "2020-08-18T00:20:18.854957796Z",
+      "progress": {
+        "message": "Operation has completed",
+        "completion": 100,
+        "created": "2020-08-18T00:20:27.428919029Z"
+      }
+    },
+    "system_status": "running",
+    "nodes": [
+      {
+        "hostname": "robotest-unit-test-node-0",
+        "advertise_ip": "10.138.0.27",
+        "role": "master",
+        "status": "healthy"
+      }
+    ]
+  }
+}
+

--- a/infra/gravity/testdata/status-degraded-5.0.36.json
+++ b/infra/gravity/testdata/status-degraded-5.0.36.json
@@ -1,0 +1,16 @@
+{
+  "cluster": {
+    "system_status": "degraded",
+    "nodes": [
+      {
+        "hostname": "",
+        "advertise_ip": "10.138.0.112",
+        "role": "master",
+        "status": "degraded",
+        "failed_probes": [
+          "etcd-healthz failed"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
This PR fixes a Gravity 5.0.x compatiblity regression introduced by https://github.com/gravitational/robotest/pull/233.  Specifically, when trying to parse the output of `gravity status --output=json` on 5.0.36 robotest would fail with the following error: `json: cannot unmarshal string into Go struct field`.

### Risk Profile
 - Bug fix (patch release)

### Related Issues
Fixes #247.

## Testing Done
See the unit tests added.  Here is what it looks like to run them:

<details><summary><code>go test ./infra/gravity</code> before the second commit</summary>

```
walt@work:~/git/robotest$ go test ./infra/gravity/
--- FAIL: TestGravity5036ActiveStatusValidation (0.00s)
    gravity_test.go:127: 
                Error Trace:    gravity_test.go:127
                Error:          Received unexpected error:
                                json: cannot unmarshal string into Go struct field ClusterStatus.cluster.system_status of type int
                Test:           TestGravity5036ActiveStatusValidation
    gravity_test.go:130: 
                Error Trace:    gravity_test.go:130
                Error:          Received unexpected error:
                                expected system_status 1, found 0
                Test:           TestGravity5036ActiveStatusValidation
--- FAIL: TestGravity5036DegradedStatusValidation (0.00s)
    gravity_test.go:147: 
                Error Trace:    gravity_test.go:147
                Error:          Received unexpected error:
                                json: cannot unmarshal string into Go struct field ClusterStatus.cluster.system_status of type int
                Test:           TestGravity5036DegradedStatusValidation
FAIL
FAIL    github.com/gravitational/robotest/infra/gravity 0.013s
FAIL
```
</details>

<details><summary><code>go test ./infra/gravity</code> after</summary>

```
walt@work:~/git/robotest$ go test ./infra/gravity/
ok      github.com/gravitational/robotest/infra/gravity (cached)
```
</details>

Here is a complete 5.0.36 install: [logs](https://console.cloud.google.com/logs/viewer?authuser=0&expandAll=false&project=kubeadm-167321&minLogLevel=0&timestamp=2020-08-19T00:46:32.173000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22project%22%0Alabels.__uuid__%3D%226a9aebd1-5e5d-4879-9cc2-2db5601f15cf%22%0Alabels.__suite__%3D%22f999ec85-c9f0-4ab2-be37-96c59d48183a%22%0Aseverity%3E%3DINFO&dateRangeStart=2020-08-18T23:46:33.411Z&dateRangeEnd=2020-08-19T00:46:33.411Z&interval=PT1H&scrollTimestamp=2020-08-19T00:42:13.093385539Z)

## Additional Information
I considered splitting the datamodel, such that GravityStatus became an interface fufilled by two different implementations: `Gravity50ClusterStatus` and `Gravity52ClusterStatus` (or the like).  I chose not to go with this approach because:
* It is more invasive. It required rewriting every signature and piece of code that consumes `GravityStatus` or any of its member fields.
* The life expectancy of this code is not that long. 5.0.x has been out of support for over a year (EoS April 13, 2019), and at some point we'll stop testing `--upgrade-via` tests from this release whereupon all this code can be removed wholesale.
