### PR TITLE
Fix log links when run from GCP nodes & opportunistic cleanups

### DIFF
--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -179,10 +179,9 @@ func (s *testSuite) getLogLink(testUID string) (string, error) {
 			"expandAll": []string{"false"},
 			"authuser":  []string{"1"},
 			"advancedFilter": []string{
-				fmt.Sprintf(`resource.type="project"
+				fmt.Sprintf(`severity>=INFO
 labels.__uuid__="%s"
-labels.__suite__="%s"
-severity>=INFO`, testUID, s.uid)},
+labels.__suite__="%s"`, testUID, s.uid)},
 		}.Encode(),
 	}
 

--- a/lib/xlog/all_test.go
+++ b/lib/xlog/all_test.go
@@ -26,10 +26,9 @@ import (
 )
 
 func TestGcl(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewGCLClient(ctx, "kubeadm-167321")
+	client, err := NewGCLClient(context.Background(), "kubeadm-167321")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("client creation failed: " + err.Error())
 	}
 	defer client.Close()
 
@@ -37,19 +36,33 @@ func TestGcl(t *testing.T) {
 
 	log := NewLogger(client, t, fields)
 
-	_, err = NewGCLClient(ctx, "doesnotexist")
-
 	log.WithFields(logrus.Fields{
 		"wrapped_no_message":   trace.Wrap(err),
 		"wrapped_with_message": trace.Wrap(err, "client error"),
 		"multi_wrap":           trace.Wrap(trace.Wrap(err)),
 		"errorf":               trace.Errorf("there was an error %v", err),
 	}).Error("structured error test")
+}
 
-	short, err := client.Shorten(ctx, `https://console.cloud.google.com/logs/viewer?project=kubeadm-167321&authuser=1&organizationId=419984272859&minLogLevel=0&expandAll=false&resource=global&advancedFilter=resource.type%3D%22global%22%0Alabels.uuid%3D%2231ef6882-0948-4a2c-81df-5bdee81d3c62%22`)
+func TestInvalidProject(t *testing.T) {
+	_, err := NewGCLClient(context.Background(), "doesnotexist")
+	if err == nil {
+		t.Fatal("expected failure when creating a client for a nonexistant project")
+	}
+}
+
+// TestShorten is an integration test for url shortening
+// As of 2020, this is expected to be broken because Google URL shortener has been discontinued.
+// See https://developers.googleblog.com/2018/03/transitioning-google-url-shortener.html for details.
+func TestShorten(t *testing.T) {
+	client, err := NewGCLClient(context.Background(), "kubeadm-167321")
 	if err != nil {
-		log.WithError(err).Error("Failed to shorten URL")
-	} else {
-		log.Info(short)
+		t.Fatal("client creation failed: " + err.Error())
+	}
+	defer client.Close()
+
+	_, err = client.Shorten(context.Background(), `https://console.cloud.google.com/logs/viewer?project=kubeadm-167321&authuser=1&organizationId=419984272859&minLogLevel=0&expandAll=false&resource=global&advancedFilter=resource.type%3D%22global%22%0Alabels.uuid%3D%2231ef6882-0948-4a2c-81df-5bdee81d3c62%22`)
+	if err != nil {
+		t.Fatal("unable to shorten url: " + err.Error())
 	}
 }

--- a/lib/xlog/shorten.go
+++ b/lib/xlog/shorten.go
@@ -58,6 +58,10 @@ func (c GCLClient) Shorten(ctx context.Context, url string) (short string, err e
 		return "", trace.Wrap(err, "reading response from URL shortener")
 	}
 
+	if resp.StatusCode != 200 {
+		return "", trace.Errorf("%v returned: %v, body: %q", shortenerEndpoint, resp.Status, data)
+	}
+
 	err = json.Unmarshal(data, &msg)
 	if err != nil {
 		return "", trace.Wrap(err, "Decoding response %q", data)


### PR DESCRIPTION
## Description
This PR includes a logging fix when the robotest container is running from a GCP node, plus some test case refactoring I did along the route to diagnosing and understanding the issue.

### Risk Profile
 - Bug fix (patch release)

### Related Issues
Fixes #265 

## Testing Done
I published robotest-suite:2.2.0-alpha.0.6-5f438094 and used that from an upcoming gravity branch on a gcp instance:
<details><summary><code>make -C build.assets/robotest run</code></summary>

```
walt@gcp:~/git/gravity$ make -C build.assets/robotest run                                                                                                                                     
make: Entering directory '/home/walt/git/gravity/build.assets/robotest'
make -j /home/walt/git/gravity/build/current/robotest/images/robotest-7.0.7.tar /home/walt/git/gravity/build/current/robotest/images/robotest-7.0.13.tar /home/walt/git/gravity/build/current/robotest/images/robotest-7.0.12.tar /home/walt/git/gravity/build/current/robotest/images/robotest-7.0.16.tar
make[1]: Entering directory '/home/walt/git/gravity/build.assets/robotest'
make[1]: '/home/walt/git/gravity/build/current/robotest/images/robotest-7.0.7.tar' is up to date.
make[1]: '/home/walt/git/gravity/build/current/robotest/images/robotest-7.0.13.tar' is up to date.                                                                                            
make[1]: '/home/walt/git/gravity/build/current/robotest/images/robotest-7.0.12.tar' is up to date.
make[1]: '/home/walt/git/gravity/build/current/robotest/images/robotest-7.0.16.tar' is up to date.
make[1]: Leaving directory '/home/walt/git/gravity/build.assets/robotest'                                                                                                                     
bash run.sh /home/walt/git/gravity/build.assets/robotest/pr_config.sh
// snip sensitive credentials
level=info msg=RUNNING commit=5f438094bc7b11af0f92655c5118f28be89bd808 logs="https://console.cloud.google.com/logs/viewer?advancedFilter=severity%3E%3DINFO%0Alabels.__uuid__%3D%22c4e8fb75-abb9-4e13-b5de-f70723b13435%22%0Alabels.__suite__%3D%22ea4b678e-1162-4e59-8ba7-d874bd53ea71%22&authuser=1&expandAll=false&project=kubeadm-167321" name=ed56b800-install-1 param="{\"role\":\"node\",\"cluster\":\"\",\"flavor\":\"three\",\"remote_support\":false,\"state_dir\":\"/var/lib/gravity\",\"os\":{\"Vendor\":\"centos\",\"Version\":\"7\"},\"storage_driver\":\"overlay2\",\"installer_url\":\"/installer/robotest-current.tar\",\"nodes\":3,\"script\":null}" version=2.2.0-alpha.0.6+5f438094 where="[/cenkalti/backof/retry.go:37]"
```
</details>

Here is the link from the run:

https://console.cloud.google.com/logs/viewer?advancedFilter=severity%3E%3DINFO%0Alabels.__uuid__%3D%22c4e8fb75-abb9-4e13-b5de-f70723b13435%22%0Alabels.__suite__%3D%22ea4b678e-1162-4e59-8ba7-d874bd53ea71%22&authuser=1&expandAll=false&project=kubeadm-167321

And a link from a run from my personal laptop (non-gcp):

https://console.cloud.google.com/logs/viewer?advancedFilter=severity%3E%3DINFO%0Alabels.__uuid__%3D%2229daa1e8-d0cc-4d5a-b0a4-b0538b80ed38%22%0Alabels.__suite__%3D%22c4d130e2-5617-432c-adee-0ff630ccee31%22&authuser=0&expandAll=false&project=kubeadm-167321
