### PR TITLE
Update GCP log link format.

### DIFF
--- a/infra/gravity/loglink_test.go
+++ b/infra/gravity/loglink_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gravity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderLogURL checks that robotest generates valid links to "new" style GCP logs (as of 2020-09)
+func TestRenderLogURL(t *testing.T) {
+	expected := "https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00.000Z%2F2020-09-22T23:33:00.000Z?project=kubeadm-167321"
+	date, err := time.Parse(time.RFC3339, "2020-09-22T22:33:00.000Z")
+	assert.NoError(t, err)
+	project := "kubeadm-167321"
+	uuid := "504d3d56-1abe-43cb-a802-3ebc96367d47"
+	suite := "d165f1b1-f40e-4e5f-8014-7bbb713d5357"
+	found := encodeLogLink(uuid, suite, project, date)
+	assert.Equal(t, expected, found)
+}

--- a/infra/gravity/loglink_test.go
+++ b/infra/gravity/loglink_test.go
@@ -25,7 +25,7 @@ import (
 
 // TestRenderLogURL checks that robotest generates valid links to "new" style GCP logs (as of 2020-09)
 func TestRenderLogURL(t *testing.T) {
-	expected := "https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00.000Z%2F2020-09-22T23:33:00.000Z?project=kubeadm-167321"
+	expected := "https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00Z%2F2020-09-22T23:33:00Z?project=kubeadm-167321"
 	date, err := time.Parse(time.RFC3339, "2020-09-22T22:33:00.000Z")
 	assert.NoError(t, err)
 	project := "kubeadm-167321"

--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -183,18 +183,18 @@ func (s *testSuite) getLogLink(testUID string) (string, error) {
 // Logic split out from getLogLink to aid in unit testing.
 //
 // The resulting url will look like:
-//   https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00.000Z%2F2020-09-22T22:35:00.000Z?authuser=0&project=kubeadm-167321
+//   https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00Z%2F2020-09-22T22:35:00Z?authuser=0&project=kubeadm-167321
 func encodeLogLink(tUID, sUID, project string, date time.Time) string {
 	// severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22
 	query := fmt.Sprintf(`severity>=INFO
 labels.__uuid__="%s"
 labels.__suite__="%s"`, tUID, sUID)
-	// 2020-09-22T22:33:00.000Z%2F2020-09-22T22:35:00.000Z
+	// 2020-09-22T22:33:00Z%2F2020-09-22T22:35:00Z
 	// The log link is generated at the start of the run. Adding
 	// 1 hour is a reasonable guess at the end of the run.
 	date = date.UTC()
-	start := date.Format("2006-01-02T15:04:05.000Z")
-	end := date.Add(1 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	start := date.Format(time.RFC3339)
+	end := date.Add(1 * time.Hour).Format(time.RFC3339)
 	window := start + "/" + end
 	longURL := url.URL{
 		Scheme: "https",

--- a/infra/gravity/testsuite.go
+++ b/infra/gravity/testsuite.go
@@ -186,9 +186,7 @@ func (s *testSuite) getLogLink(testUID string) (string, error) {
 //   https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22;timeRange=2020-09-22T22:33:00Z%2F2020-09-22T22:35:00Z?authuser=0&project=kubeadm-167321
 func encodeLogLink(tUID, sUID, project string, date time.Time) string {
 	// severity%3E%3DINFO%0Alabels.__uuid__%3D%22504d3d56-1abe-43cb-a802-3ebc96367d47%22%0Alabels.__suite__%3D%22d165f1b1-f40e-4e5f-8014-7bbb713d5357%22
-	query := fmt.Sprintf(`severity>=INFO
-labels.__uuid__="%s"
-labels.__suite__="%s"`, tUID, sUID)
+	query := fmt.Sprintf("severity>=INFO\nlabels.__uuid__=%q\nlabels.__suite__=%q", tUID, sUID)
 	// 2020-09-22T22:33:00Z%2F2020-09-22T22:35:00Z
 	// The log link is generated at the start of the run. Adding
 	// 1 hour is a reasonable guess at the end of the run.
@@ -196,6 +194,7 @@ labels.__suite__="%s"`, tUID, sUID)
 	start := date.Format(time.RFC3339)
 	end := date.Add(1 * time.Hour).Format(time.RFC3339)
 	window := start + "/" + end
+
 	longURL := url.URL{
 		Scheme: "https",
 		Host:   "console.cloud.google.com",


### PR DESCRIPTION
## Description
This new log link format provides two benefits:

 * The links now have a timestamp, meaning the view will jump to the
   relevant window, instead of requiring the user to scroll back in time
   from the moment they clicked the link.
 * [Google Logs Viewer has a new considerably nicer UI](https://cloud.google.com/logging/docs/view/logs-viewer-preview).  The new link
   navigates directly to this new UI.

### Risk Profile
 - New feature or internal change (minor release)

### Related Issues
N/A

## Testing Done

Here is a link generated from a noop test run:

https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2231993e89-276e-4e21-9ac8-df8433ef9da5%22%0Alabels.__suite__%3D%2214204050-f630-436c-8b68-d95e1877d915%22;timeRange=2020-09-23T16:05:42Z%2F2020-09-23T17:05:42Z?project=kubeadm-167321

```
walt@work:~/git/robotest$ go test -count=1 ./infra/gravity/
ok      github.com/gravitational/robotest/infra/gravity 0.014s
```
