### PR TITLE
CentOS & Redhat 8 fixes

### DIFF
--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -14,14 +14,22 @@ variable "oss" {
     "ubuntu:18"     = "ubuntu-os-cloud/ubuntu-1804-bionic-v20200807"
     "ubuntu:20"     = "ubuntu-os-cloud/ubuntu-2004-focal-v20200729"
     "ubuntu:latest" = "ubuntu-os-cloud/ubuntu-2004-focal-v20200729"
-    "redhat:7"      = "rhel-cloud/rhel-7-v20200714"
-    "redhat:8"      = "rhel-cloud/rhel-8-v20200714"
-    "centos:7"      = "centos-cloud/centos-7-v20200714"
-    "centos:8"      = "centos-cloud/centos-8-v20200714"
+
+    "redhat:7.8"    = "rhel-cloud/rhel-7-v20200910"
+    "redhat:7"      = "rhel-cloud/rhel-7-v20200910"
+    "redhat:8.2"    = "rhel-cloud/rhel-8-v20200910"
+    "redhat:8"      = "rhel-cloud/rhel-8-v20200910"
+
+    "centos:7.8"    = "centos-cloud/centos-7-v20200910"
+    "centos:7"      = "centos-cloud/centos-7-v20200910"
+    "centos:8.2"    = "centos-cloud/centos-8-v20200910"
+    "centos:8"      = "centos-cloud/centos-8-v20200910"
+
     "debian:8"      = "debian-cloud/debian-8-jessie-v20180611"
     "debian:9"      = "debian-cloud/debian-9-stretch-v20200805"
     "debian:10"     = "debian-cloud/debian-10-buster-v20200805"
     "debian:latest" = "debian-cloud/debian-10-buster-v20200805"
+
     "suse:12"       = "suse-cloud/sles-12-sp5-v20200610"
     "suse:15"       = "suse-cloud/sles-15-sp2-v20200804"
     "suse:latest"   = "suse-cloud/sles-15-sp2-v20200804"


### PR DESCRIPTION
## Description
This changeset includes several fixes/improvements to RHEL and CentOS testing:

* Bootstrap is fixed for 8.x (no longer depends on `python` in path, ensures `semanage` before use, remove deprecated sysctl)
* Updated images
* Minor versions (7.8, 8.2) are provided, for greater specificity during testing.

### Risk Profile
 - New feature or internal change (minor release)

### Related Issues
* Fixes https://github.com/gravitational/robotest/issues/258
* Fixes https://github.com/gravitational/robotest/issues/256
* Developed as part of https://github.com/gravitational/gravity/pull/2203 

## Testing Done
All below are 1 node installs with gravity 5.5.52
* [CentOS 8.2](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%224c928278-d561-4cec-ab4d-c9e4ce7924b7%22%0Alabels.__suite__%3D%22c139a11b-50ce-4df8-970a-41a57688bfae%22;timeRange=2020-10-07T19:01:08Z%2F2020-10-07T20:01:08Z?project=kubeadm-167321)
* [CentOS 7.8
](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%224c928278-d561-4cec-ab4d-c9e4ce7924b7%22%0Alabels.__suite__%3D%22c139a11b-50ce-4df8-970a-41a57688bfae%22;timeRange=2020-10-07T19:01:08Z%2F2020-10-07T20:01:08Z?project=kubeadm-167321)
* [RHEL 8.2](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%220bcfbbda-5942-4890-aac2-6412413c41e5%22%0Alabels.__suite__%3D%22c139a11b-50ce-4df8-970a-41a57688bfae%22;timeRange=2020-10-07T19:01:08Z%2F2020-10-07T20:01:08Z?project=kubeadm-167321)
* [RHEL 7.8](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%220a32fced-a91f-4b49-b6ce-7ecf4955076d%22%0Alabels.__suite__%3D%22c139a11b-50ce-4df8-970a-41a57688bfae%22;timeRange=2020-10-07T19:01:08Z%2F2020-10-07T20:01:08Z?project=kubeadm-167321)

Notably, the images were distributed via S3, to make sure the new AWS CLI is working as expected.