### PR TITLE
Add CentOS/RHEL 7.9 and 8.3 to distros offered.

### DIFF
--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -16,14 +16,18 @@ variable "oss" {
     "ubuntu:latest" = "ubuntu-os-cloud/ubuntu-2004-focal-v20200729"
 
     "redhat:7.8"    = "rhel-cloud/rhel-7-v20200910"
-    "redhat:7"      = "rhel-cloud/rhel-7-v20200910"
+    "redhat:7.9"    = "rhel-cloud/rhel-7-v20201112"
+    "redhat:7"      = "rhel-cloud/rhel-7-v20201112"
     "redhat:8.2"    = "rhel-cloud/rhel-8-v20200910"
-    "redhat:8"      = "rhel-cloud/rhel-8-v20200910"
+    "redhat:8.3"    = "rhel-cloud/rhel-8-v20201112"
+    "redhat:8"      = "rhel-cloud/rhel-8-v20201112"
 
     "centos:7.8"    = "centos-cloud/centos-7-v20200910"
-    "centos:7"      = "centos-cloud/centos-7-v20200910"
+    "centos:7.9"    = "centos-cloud/centos-7-v20201112"
+    "centos:7"      = "centos-cloud/centos-7-v20201112"
     "centos:8.2"    = "centos-cloud/centos-8-v20200910"
-    "centos:8"      = "centos-cloud/centos-8-v20200910"
+    "centos:8.3"    = "centos-cloud/centos-8-v20201112"
+    "centos:8"      = "centos-cloud/centos-8-v20201112"
 
     "debian:8"      = "debian-cloud/debian-8-jessie-v20180611"
     "debian:9"      = "debian-cloud/debian-9-stretch-v20200805"


### PR DESCRIPTION
## Description
This change adds the ability to test Gravity on CentOS/RHEL 7.9 and 8.3.  Customers have asked for this.

### Risk Profile
 - New feature or internal change (minor release) 


### Related Issues
* Contributes to https://github.com/gravitational/gravity/issues/2331

## Testing Done
* [CentOS 7.9 x Gravity 7.0.25](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2279ef7556-5966-41e0-aa71-6453b081cfb2%22%0Alabels.__suite__%3D%22c4d1195c-3f68-4a0c-8191-b1853e158f1a%22;timeRange=2020-11-13T23:24:44Z%2F2020-11-14T00:24:44Z?project=kubeadm-167321)
* [RHEL 7.9 x Gravity 7.0.25](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22ff29db0d-b288-4557-a4e4-7c807632ba97%22%0Alabels.__suite__%3D%22c4d1195c-3f68-4a0c-8191-b1853e158f1a%22;timeRange=2020-11-13T23:24:44Z%2F2020-11-14T00:24:44Z?project=kubeadm-167321)
* [RHEL 8.3 x Gravity 7.0.25](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22fab1cbc0-2110-4618-859d-5cfe86d72f14%22%0Alabels.__suite__%3D%228012276f-d2cc-4641-8c13-99497609c48c%22;timeRange=2020-11-13T20:54:41Z%2F2020-11-13T21:54:41Z?project=kubeadm-167321) (hits https://github.com/gravitational/gravity/issues/2331)

