### PR TITLE
Add Release to Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -76,8 +76,57 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish
+
+trigger:
+  event:
+  - tag
+
+steps:
+  - name: fetch tags
+    image: docker:git
+    commands:
+      - git fetch --tags
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish
+    image: docker:git
+    environment:
+      USERNAME:
+        from_secret: quay_username
+      PASSWORD:
+        from_secret: quay_password
+    commands:
+      - apk add --no-cache make
+      - docker login -u="$USERNAME" -p="$PASSWORD" quay.io
+      - make publish
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
 ---
 kind: signature
-hmac: 80f36830a4b26e813163a6f48a3ef328337385086b33fca9e0ed40b4d7b369ab
+hmac: 8852f44eb303da7fd43336fbedc0870384ab773b8771b74eb001dbbb77443b3a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,10 @@ kind: pipeline
 type: kubernetes
 name: pr
 
+trigger:
+  event:
+  - pull_request
+
 steps:
   - name: fetch tags
     image: docker:git
@@ -127,6 +131,6 @@ volumes:
     temp: {}
 ---
 kind: signature
-hmac: 8852f44eb303da7fd43336fbedc0870384ab773b8771b74eb001dbbb77443b3a
+hmac: 19562967eb86cd74334a8d81e759d479fbea9c941f2d11fd45e98dfe4905ea64
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,14 @@ endef
 $(VERSIONFILE): export CONTENT=$(VERSION_GO)
 $(VERSIONFILE): TMP = $(BUILDDIR)/$(VERSIONFILE).tmp
 $(VERSIONFILE): $(BUILDDIR)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "unable to determine version, please fetch tags"; \
+		exit 1; \
+	fi
+	@if [ -z "$(GIT_COMMIT)" ]; then \
+		echo "unable to determine current commit"; \
+		exit 1; \
+	fi
 	@echo "$$CONTENT" > $(TMP)
 	@if ! cmp -s $(TMP) $(VERSIONFILE); then \
 		echo "$$CONTENT" > $(VERSIONFILE); \

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ NOROOT := -u $$(id -u):$$(id -g)
 SRCDIR := /go/src/github.com/gravitational/robotest
 BUILDDIR ?= $(abspath build)
 # docker doesn't allow "+" in image tags: https://github.com/docker/distribution/issues/1201
-export DOCKER_VERSION ?= $(subst +,-,$(VERSION))
-export DOCKER_TAG ?=
-export DOCKER_ARGS ?= --pull
+export ROBOTEST_DOCKER_VERSION ?= $(subst +,-,$(VERSION))
+export ROBOTEST_DOCKER_TAG ?=
+export ROBOTEST_DOCKER_ARGS ?= --pull
 DOCKERFLAGS := --rm=true $(NOROOT) -v $(PWD):$(SRCDIR) -v $(BUILDDIR):$(SRCDIR)/build -w $(SRCDIR)
 BUILDBOX := robotest:buildbox
 BUILDBOX_IIDFILE := $(BUILDDIR)/.robotest-buildbox.iid

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,7 +86,10 @@ To github.com:gravitational/robotest.git
  * [new tag]         v2.0.0 -> v2.0.0
 ```
 
-### Create a draft release in GitHub.
+Pushing a tag to GitHub  will automatically kick of the Drone CI 'publish' job.
+The new artifacts will appear in quay.io shortly.
+
+### Create a Release in GitHub.
 
 Navigate to https://github.com/gravitational/robotest/releases/tag/v2.0.0
 
@@ -95,30 +98,6 @@ Click Edit Tag. Enter "Robotest 2.0.0" in the "Release Title" field.
 Add a concise note about what the release contains in the "Describe this
 release" field.
 
-Click "Save Draft".
-
-## Release
-With all the preperation taken care of, publishing the release will take only
-a minute or two, making the artifacts and release history publicly available.
-
-### Run the "Robotest-publish" Jenkins job.
-
-Navigate to: https://jenkins.gravitational.io/view/Robotest/job/Robotest-publish/
-
-Click "Build with Parameters".
-
-Enter your tag into the "GIT_REF" field, prefixed with "tags/" e.g. `tags/v2.0.0`
-
-Ignore Robotest-publish's TAG parameter. This is unneeded when an annotated
-git tag is used.
-
-Build!
-
-After the build & publish completes successfully verify the new image tag
-is present in https://quay.io/repository/gravitational/robotest-suite.
-
-### Publish the draft GitHub release.
-After the new quay.io artifact is available, publish the draft release
-created earlier in the Prepare step.
+Click "Publish Release".
 
 Congratulations! Robotest is released!

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,10 +14,10 @@
 TARGETS := e2e suite
 DOCKER_REPO := quay.io/gravitational
 # An empty version will result in build failure, call targets from the top level Makefile to set this
-DOCKER_VERSION ?=
+ROBOTEST_DOCKER_VERSION ?=
 # An empty tag will be ignored
-DOCKER_TAG ?=
-DOCKER_ARGS ?= --pull
+ROBOTEST_DOCKER_TAG ?=
+ROBOTEST_DOCKER_ARGS ?= --pull
 
 GRAVITY_VERSION := 5.5.50
 TERRAFORM_VERSION := 0.12.9
@@ -52,7 +52,7 @@ $(BINARIES):
 .PHONY: $(TARGETS)
 $(TARGETS): $(BINARIES)
 	$(eval TEMPDIR = "$(shell mktemp -d)")
-	$(eval IMAGE = $(DOCKER_REPO)/robotest-$@:$(DOCKER_VERSION))
+	$(eval IMAGE = $(DOCKER_REPO)/robotest-$@:$(ROBOTEST_DOCKER_VERSION))
 	if [ -z "$(TEMPDIR)" ]; then \
 	  echo "TEMPDIR is not set"; exit 1; \
 	fi;
@@ -61,9 +61,9 @@ $(TARGETS): $(BINARIES)
 	cp -a ../build/robotest-$@ $(TEMPDIR)/build/
 	cp -r $@/* $(TEMPDIR)/
 	if [ "$@" = "e2e" ]; then \
-	  cd $(TEMPDIR) && docker build $(E2E_BUILD_ARGS) --rm=true $(DOCKER_ARGS) -t $(IMAGE) . ; \
+	  cd $(TEMPDIR) && docker build $(E2E_BUILD_ARGS) --rm=true $(ROBOTEST_DOCKER_ARGS) -t $(IMAGE) . ; \
 	else \
-	  cd $(TEMPDIR) && docker build $(SUITE_BUILD_ARGS) --rm=true $(DOCKER_ARGS) -t $(IMAGE) . ; \
+	  cd $(TEMPDIR) && docker build $(SUITE_BUILD_ARGS) --rm=true $(ROBOTEST_DOCKER_ARGS) -t $(IMAGE) . ; \
 	fi
 	rm -rf $(TEMPDIR)
 	@echo Built $(IMAGE)
@@ -81,10 +81,10 @@ publish: $(DOCKER_REPO)/robotest-suite
 
 .PHONY: $(DOCKER_IMG)
 $(DOCKER_IMG): $(TARGETS)
-	docker push $@:$(DOCKER_VERSION)
-ifneq ($(DOCKER_TAG),)
-	docker tag $@:$(DOCKER_VERSION) $@:$(DOCKER_TAG)
-	docker push $@:$(DOCKER_TAG)
+	docker push $@:$(ROBOTEST_DOCKER_VERSION)
+ifneq ($(ROBOTEST_DOCKER_TAG),)
+	docker tag $@:$(ROBOTEST_DOCKER_VERSION) $@:$(ROBOTEST_DOCKER_TAG)
+	docker push $@:$(ROBOTEST_DOCKER_TAG)
 endif
 
 

--- a/suite/README.md
+++ b/suite/README.md
@@ -59,13 +59,6 @@ ${SCRIPT} install='{"nodes":1,"flavor":"one"}'
 
 ```
 
-## Jenkins
-
-* [Compile and test specific telekube branch](https://jenkins.gravitational.io/view/robotest/job/robotest-run/)
-* [Compile and publish Robotest](https://jenkins.gravitational.io/view/robotest/job/Robotest-publish/)
-
-Additionaly `gravity-pr` pipelines are parameterized, and will run set of robotest suites from `scripts/robotest`.
-
 ## In development
 
 The following commands in gravity repository will build telekube

--- a/version.sh
+++ b/version.sh
@@ -52,6 +52,10 @@ else
     SEMVER_TAG="${SHORT_TAG}"
 fi
 
+if [ -z "$SEMVER_TAG" ]; then # no git tags found, cannot determine version
+    exit 1
+fi
+
 if [ "$LONG_TAG" = "$SHORT_TAG" ] ; then  # the current commit is tagged as a release
     echo "${SEMVER_TAG}${DIRTY_AFFIX}"
 elif echo "$SHORT_TAG" | grep -Eq ".*-.*"; then  # the current ref is a descendant of a pre-release version (e.g. rc, alpha, or beta)


### PR DESCRIPTION
## Description
This patch introduces code & documentation changes to move the robotest release flow from Jenkins to Drone CI.

### Risk Profile
 - New feature or internal change (minor release)

### Related Issues
N/A

## Testing Done
I tagged and released 2.3.0-alpha.1 off this branch:
https://drone.gravitational.io/gravitational/robotest/61
https://quay.io/repository/gravitational/robotest-suite?tag=latest&tab=tags

There appears to be about a 10% difference in image size -- I suspect this is due to some old base images cached in Jenkins.  The new image size is consistent with what I get when I build locally.

For the version.sh changes:
<details><summary><code>make version</code></summary>

```
$ make version
version metadata saved to version.go
Robotest Version: 2.3.0-alpha.1.1+582636d8
walt@work:~/git/robotest$ git tag -d $(git tag -l)
Deleted tag '0.0.1' (was 40d0691)
Deleted tag '1.0.0' (was 84d666c)
Deleted tag 'v2.0.0' (was fffcac0)
Deleted tag 'v2.0.0-alpha.1' (was d5bb675)
Deleted tag 'v2.0.0-rc.1' (was 951b341)
Deleted tag 'v2.1.0' (was 4780422)
Deleted tag 'v2.1.0-alpha.0' (was fa4b21c)
Deleted tag 'v2.1.0-rc.1' (was 959c2bb)
Deleted tag 'v2.1.1' (was ca1dfcf)
Deleted tag 'v2.2.0' (was be9dc44)
Deleted tag 'v2.2.0-alpha.0' (was 9d5e627)
Deleted tag 'v2.3.0-alpha.0' (was ac0d34f)
Deleted tag 'v2.3.0-alpha.1' (was 40197e2)
walt@work:~/git/robotest$ make version
fatal: No names found, cannot describe anything.
fatal: No names found, cannot describe anything.
unable to determine version, please fetch tags
make: *** [Makefile:130: version.go] Error 1
```
</details>

## Additional Information
I added a new purpose specific robot account to quay for this publishing: `gravitational+drone_robotest_publish`, following the principle of least privilege.