### PR TITLE
Install awscli without python/pip

### DIFF
--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -112,6 +112,7 @@ if ! /usr/local/bin/aws --version; then
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
   unzip awscliv2.zip
   ./aws/install
+  rm -rf awscliv2.zip ./aws
 fi
 
 if ! grep -qs "$etcd_dir" /proc/mounts; then

--- a/assets/terraform/gce/bootstrap/sles.sh
+++ b/assets/terraform/gce/bootstrap/sles.sh
@@ -85,6 +85,7 @@ if ! /usr/local/bin/aws --version; then
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
   unzip awscliv2.zip
   ./aws/install
+  rm -rf awscliv2.zip ./aws
 fi
 
 

--- a/assets/terraform/gce/bootstrap/sles.sh
+++ b/assets/terraform/gce/bootstrap/sles.sh
@@ -81,23 +81,12 @@ mkdir -p $etcd_dir /var/lib/data
 secure-ssh
 setup-user
 
-function install-aws-cli {
-  # suse-cloud/sles-15-sp1-v20200415 has no python, but offers python3.
-  # suse-cloud/sles-12-sp5-v20200227 has both, but it's python3 < 3.5 and is
-  # incompatible with awscli.
-  if command -v python; then
-    local python=$(command -v  python)
-  elif command -v python3; then
-    local python=$(command -v python3)
-  else
-    echo "No python available."
-    exit 2
-  fi
-  curl https://bootstrap.pypa.io/get-pip.py | $python -
-  $python -m pip install --upgrade awscli
-}
+if ! /usr/local/bin/aws --version; then
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
+  ./aws/install
+fi
 
-install-aws-cli
 
 mkdir -p /var/lib/gravity/planet/etcd /var/lib/data
 

--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -101,6 +101,7 @@ if ! /usr/local/bin/aws --version; then
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
   unzip awscliv2.zip
   ./aws/install
+  rm -rf awscliv2.zip ./aws
 fi
 
 if ! grep -qs "$etcd_dir" /proc/mounts; then

--- a/assets/terraform/gce/bootstrap/ubuntu.sh
+++ b/assets/terraform/gce/bootstrap/ubuntu.sh
@@ -94,10 +94,14 @@ setup-user
 echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries
 
 apt-get update
-apt-get install -y chrony lvm2 curl wget thin-provisioning-tools python
+apt-get install -y chrony lvm2 curl wget thin-provisioning-tools
 
-curl https://bootstrap.pypa.io/get-pip.py | python -
-pip install --upgrade awscli
+if ! /usr/local/bin/aws --version; then
+  apt-get install -y unzip
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
+  ./aws/install
+fi
 
 if ! grep -qs "$etcd_dir" /proc/mounts; then
   mkfs.ext4 -F /dev/$etcd_device_name


### PR DESCRIPTION
## Description
This avoids the need to install python or use pip to install v1 of the AWS cli.  This recently became important because after https://github.com/pypa/pip/pull/9189, pip no longer runs with many distros default python 2.7 resulting in failures like #279.


### Risk Profile

 - Bug fix (patch release)

### Related Issues
* Fixes #279 

## Testing Done
See the following automates runs:

* [sles 12-sp5](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22647bedb6-d141-4bfb-90cd-3173022e267a%22%0Alabels.__suite__%3D%22afbedaaa-b62c-45e9-8ee9-e85a85447b1f%22;timeRange=2021-01-27T03:43:49Z%2F2021-01-27T04:43:49Z?project=kubeadm-167321)
* [ubuntu 18.04](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%223d7d4650-13ea-4915-b49e-578d50525aed%22%0Alabels.__suite__%3D%22afbedaaa-b62c-45e9-8ee9-e85a85447b1f%22;timeRange=2021-01-27T03:43:49Z%2F2021-01-27T04:43:49Z?project=kubeadm-167321)

RHEL/CentOS already has this change, introduces as part of the RHEL 8 work in #268.