### PR TITLE
Remove epel and gcloud rpm repos

### DIFF
--- a/assets/terraform/gce/bootstrap/centos.sh
+++ b/assets/terraform/gce/bootstrap/centos.sh
@@ -91,9 +91,15 @@ function setup-user {
   sed -i.bak 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers
 }
 
-# Yum hits "Error: Cannot retrieve metalink for repository: epel." on some images.
-# According to https://stackoverflow.com/a/27667111, this is a certificate issue.
-yum --disablerepo=epel -y update ca-certificates
+
+# Before running any yum operations, remove unneeded and historically flaky repos. See:
+#  - https://github.com/gravitational/robotest/issues/214
+#  - https://github.com/gravitational/robotest/issues/282
+rm -f /etc/yum.repos.d/epel.repo
+rm -f /etc/yum.repos.d/epel-testing.repo
+rm -f /etc/yum.repos.d/google-cloud.repo
+
+yum -y update ca-certificates
 yum -y install chrony
 
 mkdir -p $etcd_dir /var/lib/data


### PR DESCRIPTION
## Description
The epel and gcloud repos have been a consistent source of failures
during the bootstrap execution -- typicially due to changes in infrastructure
outside of Gravitational's control.  As we don't need packages from either
of these repos for Robotest, we can nuke them before attempting any yum
operations they could disrupt.

### Risk Profile
 - New feature or internal change (minor release)

### Related Issues
* Mitigates https://github.com/gravitational/robotest/issues/282 and https://github.com/gravitational/robotest/issues/214

## Testing Done
Centos 7, 8, RHEL 7, 8 all tested here:

https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__suite__%3D%22827ba907-aaec-4bdf-9077-b38fd1727de1%22;timeRange=2021-04-01T19:57:05Z%2F2021-04-01T20:57:05Z?project=kubeadm-167321
