### PR TITLE
Add RHEL/CentOS 8.4 to supported distros

### DIFF
--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -20,14 +20,16 @@ variable "oss" {
     "redhat:7"      = "rhel-cloud/rhel-7-v20201112"
     "redhat:8.2"    = "rhel-cloud/rhel-8-v20200910"
     "redhat:8.3"    = "rhel-cloud/rhel-8-v20201112"
-    "redhat:8"      = "rhel-cloud/rhel-8-v20201112"
+    "redhat:8.4"    = "rhel-cloud/rhel-8-v20210701"
+    "redhat:8"      = "rhel-cloud/rhel-8-v20210701"
 
     "centos:7.8"    = "centos-cloud/centos-7-v20200910"
     "centos:7.9"    = "centos-cloud/centos-7-v20201112"
     "centos:7"      = "centos-cloud/centos-7-v20201112"
     "centos:8.2"    = "centos-cloud/centos-8-v20200910"
     "centos:8.3"    = "centos-cloud/centos-8-v20201112"
-    "centos:8"      = "centos-cloud/centos-8-v20201112"
+    "centos:8.4"    = "centos-cloud/centos-8-v20210701"
+    "centos:8"      = "centos-cloud/centos-8-v20210701"
 
     "debian:8"      = "debian-cloud/debian-8-jessie-v20180611"
     "debian:9"      = "debian-cloud/debian-9-stretch-v20200805"


### PR DESCRIPTION
## Description
Like the title says!

### Risk Profile
 - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->


### Related Issues
* https://github.com/gravitational/gravity/issues/2563

## Testing Done
3 node upgrade from 8.0.0-apha.0 to 9.0.0-beta.2: https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2294aeba7e-c495-4ac2-aeea-b7c23dbc826a%22%0Alabels.__suite__%3D%221162a757-f510-47de-b6a0-692225f76ad9%22;timeRange=2021-07-20T21:39:51Z%2F2021-07-20T22:39:51Z?project=robotest-production

I also did a one node install on 7.0.33, but my cloud logging config was broken that run, so I can't point to the logs.

## Additional Information
CentOS has switchted from long lived releases to "centos-stream": https://www.centos.org/centos-stream/

However the image I grabbed happens to align with 8.4:

```console
[centos@robotest-6bfbb7a9-node-0 ~]$ cat /etc/*-release
CentOS Linux release 8.4.2105                                                                  
NAME="CentOS Linux"                                                                            
VERSION="8"                                                                                    
ID="centos"                                                                                    
ID_LIKE="rhel fedora"                                                                          
VERSION_ID="8"                                                                                 
PLATFORM_ID="platform:el8"                                                                     
PRETTY_NAME="CentOS Linux 8"                                                                   
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"                                                              
HOME_URL="https://centos.org/"                                                                 
BUG_REPORT_URL="https://bugs.centos.org/"                                                      
CENTOS_MANTISBT_PROJECT="CentOS-8" 
CENTOS_MANTISBT_PROJECT_VERSION="8"                                                            
CentOS Linux release 8.4.2105                                                                  
CentOS Linux release 8.4.2105    
```
