### PR TITLE
Upgrade go to 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,4 +150,4 @@ $(VERSIONFILE): $(BUILDDIR)
 .PHONY: $(TARGETS)
 $(TARGETS): $(VERSIONFILE)
 	@go version
-	go test -c -i ./$(subst robotest-,,$@) -o build/robotest-$@
+	go test -c ./$(subst robotest-,,$@) -o build/robotest-$@

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM quay.io/gravitational/debian-venti:go1.15.5-buster
+FROM quay.io/gravitational/debian-venti:go1.16.6-buster
 
 ARG UID
 ARG GID

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/robotest
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.72.0 // indirect


### PR DESCRIPTION
## Description
This also required removing the `go test -i` flag, which has been
deprecated, as it no longer provides any useful value:

  https://golang.org/doc/go1.16#i-flag

### Risk Profile
 - New feature or internal change (minor release) <!-- A non-API-breaking change which adds new functionality or improves Robotest's code without fixing a bug. -->

### Related Issues
N/A

## Testing Done
<details><summary><code>make build</code></summary>

```
walt@aws:~/git/robotest$ git checkout go-1.16
Switched to branch 'go-1.16'
walt@aws:~/git/robotest$ make build
version metadata saved to version.go
docker build  --tag robotest:buildbox \
        --build-arg UID=$(id -u) \
        --build-arg GID=$(id -g) \
        --build-arg GOLANGCI_LINT_VER=1.32.2 \
        --iidfile /home/walt/git/robotest/build/.robotest-buildbox.iid \
        docker/build
Sending build context to Docker daemon  3.584kB
Step 1/12 : FROM quay.io/gravitational/debian-venti:go1.16.6-buster
 ---> 28677cb1de3c
Step 2/12 : ARG UID
 ---> Using cache
 ---> 04d9321a040f
Step 3/12 : ARG GID
 ---> Using cache
 ---> 351325c6bd8e
Step 4/12 : ARG GOLANGCI_LINT_VER
 ---> Using cache
 ---> 2083d0877685
Step 5/12 : ENV GOPACKAGESPRINTGOLISTERRORS=true
 ---> Using cache
 ---> bab31875b342
Step 6/12 : RUN getent group  $GID || groupadd builder --gid=$GID -o;     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/bash;
 ---> Using cache
 ---> 7cfb20c5b49a
Step 7/12 : RUN (mkdir -p /go/src/github.com/gravitational/robotest && chown -R $UID:$GID /go ${GOPATH})
 ---> Using cache
 ---> 445be84b5bc1
Step 8/12 : RUN (mkdir -p /go/bin)
 ---> Using cache
 ---> fe099506d8d2
Step 9/12 : ENV LANGUAGE="en_US.UTF-8"     LANG="en_US.UTF-8"     LC_ALL="en_US.UTF-8"     LC_CTYPE="en_US.UTF-8"     GOPATH="/gopath"     PATH="$PATH:/opt/go/bin:/go/bin"
 ---> Using cache
 ---> 1c4d86248970
Step 10/12 : RUN (wget -q https://github.com/golangci/golangci-lint/releases/download/v$GOLANGCI_LINT_VER/golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz &&        tar -xvf golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz -C /go/bin               golangci-lint-$GOLANGCI_LINT_VER-linux-amd64/golangci-lint --strip-components=1 &&      rm golangci-lint-$GOLANGCI_LINT_VER-linux-amd64.tar.gz)
 ---> Using cache
 ---> ae1d5fb03c26
Step 11/12 : WORKDIR /gopath/src/github.com/gravitational/robotest
 ---> Using cache
 ---> 1f558a1174cb
Step 12/12 : VOLUME ["/gopath/src/github.com/gravitational/robotest"]
 ---> Using cache
 ---> 95a78402b90e
Successfully built 95a78402b90e
Successfully tagged robotest:buildbox
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest robotest:buildbox \
        dumb-init go mod vendor
go: downloading github.com/sclevine/agouti v0.0.0-20180825234404-5e39ce136dd6
go: downloading github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23
go: downloading github.com/gravitational/trace v1.1.11
go: downloading github.com/hashicorp/go-version v1.2.1
go: downloading github.com/onsi/ginkgo v1.14.2
go: downloading github.com/onsi/gomega v1.10.3
go: downloading github.com/sirupsen/logrus v1.7.0
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
go: downloading gopkg.in/go-playground/validator.v9 v9.31.0
go: downloading github.com/google/go-cmp v0.5.3
go: downloading cloud.google.com/go v0.72.0
go: downloading github.com/aws/aws-sdk-go v1.35.34
go: downloading cloud.google.com/go/bigquery v1.13.0
go: downloading github.com/cenkalti/backoff v2.2.1+incompatible
go: downloading github.com/dustin/go-humanize v1.0.0
go: downloading github.com/satori/go.uuid v1.2.0
go: downloading github.com/stretchr/testify v1.6.1
go: downloading golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
go: downloading cloud.google.com/go/logging v1.1.2
go: downloading golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
go: downloading github.com/kr/text v0.2.0
go: downloading github.com/jonboulle/clockwork v0.2.2
go: downloading golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
go: downloading github.com/go-playground/universal-translator v0.17.0
go: downloading github.com/leodido/go-urn v1.2.0
go: downloading github.com/googleapis/gax-go/v2 v2.0.5
go: downloading google.golang.org/api v0.35.0
go: downloading google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/golang/protobuf v1.4.3
go: downloading golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
go: downloading google.golang.org/appengine v1.6.7
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading github.com/nxadm/tail v1.4.5
go: downloading github.com/go-playground/locales v0.13.0
go: downloading github.com/jstemmer/go-junit-report v0.9.1
go: downloading golang.org/x/lint v0.0.0-20200302205851-738671d3881b
go: downloading golang.org/x/tools v0.0.0-20201123190950-db3e1ec26de3
go: downloading google.golang.org/grpc v1.33.2
go: downloading go.opencensus.io v0.22.5
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading google.golang.org/protobuf v1.25.0
go: downloading golang.org/x/text v0.3.4
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
go: downloading github.com/fsnotify/fsnotify v1.4.9
go: downloading golang.org/x/mod v0.3.0
docker run --rm=true -u $(id -u):$(id -g) -v /home/walt/git/robotest:/go/src/github.com/gravitational/robotest -v /home/walt/git/robotest/build:/go/src/github.com/gravitational/robotest/build -w /go/src/github.com/gravitational/robotest robotest:buildbox \
        dumb-init make -j e2e suite
go version go1.16.6 linux/amd64
go version go1.16.6 linux/amd64
go test -c ./e2e -o build/robotest-e2e
go test -c ./suite -o build/robotest-suite
walt@aws:~/git/robotest$
```
</details>
