### PR TITLE
Update sles images

### DIFF
--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -36,15 +36,16 @@ variable "oss" {
     "debian:10"     = "debian-cloud/debian-10-buster-v20210817"
     "debian:latest" = "debian-cloud/debian-10-buster-v20210817"
 
-    # suse is an alias of sles for backwards compatibility, may be removed in 3.0
-    "suse:12"       = "suse-cloud/sles-12-sp5-v20200916"
-    "suse:15"       = "suse-cloud/sles-15-sp2-v20201014"
-    "suse:latest"   = "suse-cloud/sles-15-sp2-v20201014"
+    # suse is an alias of sles for backwards compatibility, may be removed in a later version
+    "suse:12"       = "suse-cloud/sles-12-sp5-v20210605"
+    "suse:15"       = "suse-cloud/sles-15-sp3-v20210812"
+    "suse:latest"   = "suse-cloud/sles-15-sp3-v20210812"
 
-    "sles:12-sp5"   = "suse-cloud/sles-12-sp5-v20200916"
-    "sles:12"       = "suse-cloud/sles-12-sp5-v20200916"
-    "sles:15-sp2"   = "suse-cloud/sles-15-sp2-v20201014"
-    "sles:15"       = "suse-cloud/sles-15-sp2-v20201014"
+    "sles:12-sp5"   = "suse-cloud/sles-12-sp5-v20210605"
+    "sles:12"       = "suse-cloud/sles-12-sp5-v20210605"
+    "sles:15-sp2"   = "suse-cloud/sles-15-sp2-v20210604"
+    "sles:15-sp3"   = "suse-cloud/sles-15-sp3-v20210812"
+    "sles:15"       = "suse-cloud/sles-15-sp3-v20210812"
   }
 }
 


### PR DESCRIPTION
## Description
`suse-cloud/sles-15-sp2-v20201014` no longer exists in GCP, and we may as well update the other images.

### Risk Profile
 - Bug fix (patch release)

### Related Issues
* Fixes #290.

## Testing Done
* [sles12-sp5 logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%2267aefdec-b6a1-4d9a-bf37-1aed24480bef%22%0Alabels.__suite__%3D%222d3e804e-b1d7-49bc-a53b-281f1a754e78%22;timeRange=2021-08-26T01:33:02Z%2F2021-08-26T02:33:02Z;cursorTimestamp=2021-08-26T01:44:33.576122638Z?project=robotest-production)
* [sles15-sp2 logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22b49bff62-a120-4d97-98f7-8a0f42f2a895%22%0Alabels.__suite__%3D%222d3e804e-b1d7-49bc-a53b-281f1a754e78%22;timeRange=2021-08-26T01:33:02Z%2F2021-08-26T02:33:02Z;cursorTimestamp=2021-08-26T01:33:02.978553061Z?project=robotest-production)
* [sles15-sp3 logs](https://console.cloud.google.com/logs/query;query=severity%3E%3DINFO%0Alabels.__uuid__%3D%22fd578bf8-3cf8-48c6-9e48-8f1523880814%22%0Alabels.__suite__%3D%222d3e804e-b1d7-49bc-a53b-281f1a754e78%22;timeRange=2021-08-26T01:33:02Z%2F2021-08-26T02:33:02Z;cursorTimestamp=2021-08-26T01:33:02.978182326Z?project=robotest-production)
