### PR TITLE
Replace sles-15-sp2 image

### DIFF
--- a/assets/terraform/gce/os.tf
+++ b/assets/terraform/gce/os.tf
@@ -44,6 +44,7 @@ variable "oss" {
     "sles:12-sp5"   = "suse-cloud/sles-12-sp5-v20210605"
     "sles:12"       = "suse-cloud/sles-12-sp5-v20210605"
     "sles:15-sp2"   = "suse-cloud/sles-15-sp2-v20210604"
+    "sles:15-sp2"   = "suse-sap-cloud/sles-15-sp2-sap-v20210604"
     "sles:15-sp3"   = "suse-cloud/sles-15-sp3-v20210812"
     "sles:15"       = "suse-cloud/sles-15-sp3-v20210812"
   }


### PR DESCRIPTION
## Description
<!-- Required. Provide a concise overview of *why* this change is important. -->
This replaces the `sles-15-sp2` image from google cloud. This image is no longer available and causing robotest to fail.

### Risk Profile
<!-- Required. Remove all but one. Refer to https://semver.org/spec/v2.0.0.html and https://github.com/gravitational/robotest/blob/master/RELEASE.md-->
 - Bug fix (patch release) <!-- An API compatible internal change which fixes incorrect behavior linked in Related Issues. Bug fixes shall include an automated test case that fails without the fix and pass with it. -->

### Related Issues
<!-- Optional, but highly recommended. Remove this section if unneeded. -->
- https://github.com/gravitational/gravity/issues/2703

## Testing Done
<!-- Required.
Show the testing you did with shell transcripts, links to logs and/or a mention of the automated test cases that were added. Provide enough information that a co-contributor (or CI system) could reproduce your testing. -->
TODO...
<details><summary><code><!-- make test? --></code></summary>

<pre>
<!--
Stub collapsible details provided for convenience.
Shell transcript goes here.
-->
</pre>
</details>
